### PR TITLE
Strat renaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
         <option value="no">Don't sim</option>
       </select><br /><br />
       <!--span>Skip completed CTs in "all" mode: </span> <input type="checkbox" class="skipcompletedcts" /><br /><br /-->
-      <span>Show a2 and a3 lvl in EFAI strat output: </span> <input type="checkbox" class="a23" /><br /><br />
+      <span>Show a2 and a3 lvl in EFMod strat output: </span> <input type="checkbox" class="a23" /><br /><br />
       <span>Show unofficial CTs: </span> <input type="checkbox" class="unofficials" /><br /><br />
       <span>Generate a total purchase list: </span> <input type="checkbox" class="totalPurchaseList" /><br /><br />
     </dialog>

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -471,13 +471,13 @@
         "SLCoast": {
           "stratFilterCondition": "Semi-Idle"
         },
-        "SLdCoast": {
+        "SLModCoast": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 300"
         },
-        "SLMS": {
+        "SLMSMC": {
           "stratFilterCondition": "Active && rho < 300"
         },
-        "SLMSd": {
+        "SLMSModMC": {
           "stratFilterCondition": "Very-Active && rho < 300"
         }
       }
@@ -488,13 +488,13 @@
         "EF": {
           "stratFilterCondition": "Idle || rho < 10"
         },
-        "EFSnax": {
+        "EFStopQ1BXCX": {
           "stratFilterCondition": "Semi-Idle"
         },
         "EFd": {
           "stratFilterCondition": "(Active || Very-Active) && rho < 10"
         },
-        "EFAI": {
+        "EFMod": {
           "stratFilterCondition": "Active || Very-Active"
         },
         "EFModStage": {

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -51,19 +51,16 @@
         "T2MC": {
           "stratFilterCondition": "!Idle && rho >= 250"
         },
-        "T2MCAlt": {
-          "stratFilterCondition": "false"
-        },
-        "T2MCAlt2": {
+        "T2MC2": {
           "stratFilterCondition": "!Idle && rho >= 250"
         },
-        "T2MCAlt3": {
+        "T2MC3": {
           "stratFilterCondition": "!Idle && rho >= 250"
         },
         "T2MS": {
           "stratFilterCondition": "(Active || Very-Active) && rho < 250"
         },
-        "T2QS": {
+        "T2SingleMS": {
           "stratFilterCondition": "Semi-Idle && rho < 250"
         },
         "T2Haxolotl":  {
@@ -78,21 +75,14 @@
           "stratFilterCondition": "Very-Active && rho > 250 ",
           "forcedCondition": "rho >= 125"
         },
-        "T3Play": {
-          "stratFilterCondition": "Very-Active && rho > 200 && rho < 375",
-          "forcedCondition": "rho >= 125"
-        },
-        "T3Snax": {
+        "T3NoC11C13C21StopB1C3X": {
           "stratFilterCondition": "Semi-Idle && rho >= 175"
         },
-        "T3SnaxCoast": {
+        "T3NoC11C13C21StopB1C3XCoast": {
           "stratFilterCondition": "Semi-Idle && rho >= 175"
         },
-        "T3SnaxdC12": {
+        "T3NoC11C13C21StopB1C3XRcvA": {
           "stratFilterCondition": "Active && rho >= 175"
-        },
-        "T3Snax2": {
-          "stratFilterCondition": "Active && rho > 275 && rho < 500"
         },
         "T3P2C23d": {
           "stratFilterCondition": "Active && rho > 250 ",

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -620,13 +620,13 @@
         "RZdBH": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 600"
         },
-        "RZSpiralswap": {
+        "RZdSpiralMS": {
           "stratFilterCondition": "Very-Active && rho >= 50 && rho < 400"
         },
-        "RZMS": {
+        "RZSingleMS": {
           "stratFilterCondition": "Semi-Idle && rho >= 50 && rho < 400"
         },
-        "RZdMS": {
+        "RZdSingleMS": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 50 && rho < 400"
         },
         "RZdBHRewind" : {

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -452,13 +452,13 @@
         "WSPStopC1Coast": {
           "stratFilterCondition": "Semi-Idle"
         },
-        "WSPdStopC1": {
+        "WSPMod": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "WSPdStopC1Coast": {
+        "WSPModCoast": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "WSPPostRecoveryStopC1Coast": {
+        "WSPModRcvICoast": {
           "stratFilterCondition": "false"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -57,7 +57,7 @@
         "T2SingleMS": {
           "stratFilterCondition": "Semi-Idle && rho < 250"
         },
-        "T2Haxolotl":  {
+        "T2dMC":  {
           "stratFilterCondition": "false"
         }
       }
@@ -65,7 +65,7 @@
     "T3": {
       "tauFactor": 1,
       "strats": {
-        "T3Play2": {
+        "T3dStage": {
           "stratFilterCondition": "Very-Active && rho > 250 ",
           "forcedCondition": "rho >= 125"
         },
@@ -95,11 +95,11 @@
         "T3P2C23C33Coast": {
           "stratFilterCondition": "Semi-Idle && rho > 400"
         },
-        "T3noC11C13C21C33d": {
+        "T3P2C23C31d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 150 && rho < 350",
           "forcedCondition": "rho >= 125"
         },
-        "T3noC11C13C21C33": {
+        "T3P2C23C31": {
           "stratFilterCondition": "Idle && rho >= 175 && rho < 300"
         },
         "T3noC13C33d": {

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -514,11 +514,11 @@
         "CSR2d": {
           "stratFilterCondition": "Active && rho < 500"
         },
-        "CSR2XL": {
-          "stratFilterCondition": "((Active && rho >= 500) || Very-Active) && rho >= 10 && (rho < 500 || rho >= 1499)"
+        "CSR2Mod": {
+          "stratFilterCondition": "Active || Very-Active"
         },
-        "CSR2XLPT": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 500 && rho < 1499"
+        "CSR2MSMod": {
+          "stratFilterCondition": "Very-Active && rho >= 10 && rho < 500"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -353,19 +353,19 @@
           "stratFilterCondition": "Semi-Idle && rho >= 100 && rho < 550",
           "forcedCondition": "rho >= 25"
         },
-        "T7noC123": {
+        "T7C456": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho > 500 && rho < 625",
           "forcedCondition": "rho >= 75"
         },
-        "T7noC123Coast": {
+        "T7C456Coast": {
           "stratFilterCondition": "Semi-Idle && rho > 500 && rho < 625",
           "forcedCondition": "rho >= 75"
         },
-        "T7noC1234": {
+        "T7C56": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho > 525",
           "forcedCondition": "rho >= 75"
         },
-        "T7noC1234Coast": {
+        "T7C56Coast": {
           "stratFilterCondition": "Semi-Idle && rho > 525",
           "forcedCondition": "rho >= 75"
         },
@@ -408,7 +408,7 @@
         "T8noC35": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 100 && rho < 160"
         },
-        "T8Snax": {
+        "T8MC": {
           "stratFilterCondition": "Semi-Idle"
         },
         "T8Coast": {
@@ -432,10 +432,10 @@
         "T8PlayCoast": {
           "stratFilterCondition": "Active && rho >= 220"
         },
-        "T8PlaySolarswap": {
+        "T8PlaySolarReset": {
           "stratFilterCondition": "Very-Active"
         },
-        "T8PlaySolarswapCoast": {
+        "T8PlaySolarResetCoast": {
           "stratFilterCondition": "Very-Active"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -741,21 +741,11 @@
         "BaPcoast": {
           "stratFilterCondition": "Semi-Idle && rho < 1500"
         },
-        "BaPAI": {
+        "BaPModBurstC1": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "BaPAIMS": {
+        "BaPMSModBurstC1": {
           "stratFilterCondition": "(Active || Very-Active) && rho < 250"
-        },
-        "BaPAIMS2": {
-          "UI_visible":false,
-          "stratFilterCondition": "(Active || Very-Active) && rho < 250 && false"
-        },
-        "BaPd": {
-          "stratFilterCondition": "false"
-        },
-        "BaPdMS": {
-          "stratFilterCondition": "false"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -425,16 +425,16 @@
         "T8d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 40 && rho < 100"
         },
-        "T8Play": {
+        "T8Mod": {
           "stratFilterCondition": "Active && rho >= 220"
         },
-        "T8PlayCoast": {
+        "T8ModCoast": {
           "stratFilterCondition": "Active && rho >= 220"
         },
-        "T8PlaySolarReset": {
+        "T8ModReset": {
           "stratFilterCondition": "Very-Active"
         },
-        "T8PlaySolarResetCoast": {
+        "T8ModResetCoast": {
           "stratFilterCondition": "Very-Active"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -377,12 +377,20 @@
           "stratFilterCondition": "(Active || Very-Active) && rho >= 25 && rho < 75",
           "forcedCondition": "rho >= 25"
         },
-        "T7PlaySpqcey": {
+        "T7NoC12d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 100",
           "forcedCondition": "rho >= 100"
         },
-        "T7PlaySpqceyCoast": {
+        "T7NoC12dCoast": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 100",
+          "forcedCondition": "rho >= 100"
+        },
+        "T7Ratio": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 100 && rho < 300",
+          "forcedCondition": "rho >= 100"
+        },
+        "T7RatioCoast": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 100 && rho < 300",
           "forcedCondition": "rho >= 100"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -31,7 +31,7 @@
         "T1RatioCoast": {
           "stratFilterCondition": "(Very-Active && rho < 250) || Active"
         },
-        "T1SolarXLII": {
+        "T1ModRatio": {
           "stratFilterCondition": "Very-Active"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -237,46 +237,46 @@
           "stratFilterCondition": "false",
           "forcedCondition": "rho >= 125"
         },
-        "T6Snax": {
+        "T6C125StopC12": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxCoast": {
+        "T6C125StopC12Coast": {
           "stratFilterCondition": "Semi-Idle && rho >= 400"
         },
-        "T6SnaxIdleRecovery": {
+        "T6C125dStopC12RcvI": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryCoast": {
+        "T6C125dStopC12RcvICoast": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM1": {
+        "T6C125dStopC12RcvI1": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM1Coast": {
+        "T6C125dStopC12RcvI1Coast": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM2": {
+        "T6C125dStopC12RcvI2": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM2Coast": {
+        "T6C125dStopC12RcvI2Coast": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM3": {
+        "T6C125dStopC12RcvI3": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM3Coast": {
+        "T6C125dStopC12RcvI3Coast": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM4": {
+        "T6C125dStopC12RcvI4": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM4Coast": {
+        "T6C125dStopC12RcvI4Coast": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM5": {
+        "T6C125dStopC12RcvI5": {
           "stratFilterCondition": "false"
         },
-        "T6SnaxIdleRecoveryM5Coast": {
+        "T6C125dStopC12RcvI5Coast": {
           "stratFilterCondition": "false"
         },
         "T6C3d": {
@@ -300,18 +300,18 @@
           "stratFilterCondition": "Active && rho >= 800",
           "forcedCondition": "rho >= 125"
         },
-        "T6C5dIdleRecovery": {
+        "T6C5dRcvI": {
           "stratFilterCondition": "false",
           "forcedCondition": "rho >= 125"
         },
-        "T6C5dIdleRecoveryCoast": {
+        "T6C5dRcvICoast": {
           "stratFilterCondition": "false",
           "forcedCondition": "rho >= 125"
         },
-        "T6AI": {
+        "T6NoC34Mod": {
           "stratFilterCondition": "Very-Active && rho >= 100"
         },
-        "T6AICoast": {
+        "T6NoC34ModCoast": {
           "stratFilterCondition": "Very-Active && rho >= 100"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -503,7 +503,7 @@
         "EFAI": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "EFPlay": {
+        "EFModStage": {
           "stratFilterCondition": "false && Very-Active && rho > 50"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -193,13 +193,10 @@
         "T5": {
           "stratFilterCondition": "Idle || rho < 25"
         },
-        "T5Idle": {
-          "stratFilterCondition": "false"
-        },
-        "T5IdleCoast": {
+        "T5RcvA": {
           "stratFilterCondition": "Semi-Idle"
         },
-        "T5Idle2Coast": {
+        "T5RcvA2": {
           "stratFilterCondition": "false"
         },
         "T5ManageQMod": {

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -585,16 +585,16 @@
         "FPcoast": {
           "stratFilterCondition": "Semi-Idle && rho >= 1200 && rho < 3490"
         },
-        "FPd": {
+        "FPMod": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "FPdMS": {
+        "FPMSMod": {
           "stratFilterCondition": "(Active || Very-Active) && rho > 700 && rho < 1050"
         },
-        "FPmodBurstC1": {
+        "FPModBurstC1": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "FPmodBurstC1MS": {
+        "FPMSModBurstC1": {
           "stratFilterCondition": "(Active || Very-Active) && rho > 700 && rho < 1050"
         }
       }

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -468,14 +468,8 @@
         "SL": {
           "stratFilterCondition": "Idle || rho < 25"
         },
-        "SLStopA": {
-          "stratFilterCondition": "Semi-Idle"
-        },
         "SLCoast": {
           "stratFilterCondition": "Semi-Idle"
-        },
-        "SLStopAd": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 300"
         },
         "SLdCoast": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 300"

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -33,12 +33,6 @@
         },
         "T1SolarXLII": {
           "stratFilterCondition": "Very-Active"
-        },
-        "T1SolarXLIIOld": {
-          "stratFilterCondition": "false"
-        },
-        "T1SolarXLIIOldCoast": {
-          "stratFilterCondition": "false"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -202,10 +202,10 @@
         "T5Idle2Coast": {
           "stratFilterCondition": "false"
         },
-        "T5AI2": {
+        "T5ManageQMod": {
           "stratFilterCondition": "Active || Very-Active"
         },
-        "T5AI2Coast": {
+        "T5ManageQModCoast": {
           "stratFilterCondition": "Active || Very-Active"
         }
       }
@@ -532,22 +532,22 @@
         "FICoast":{
           "stratFilterCondition":"Semi-Idle || (!Idle && rho <= 30)"
         },
-        "FId": {
+        "FIMod": {
           "stratFilterCondition":"Active || Very-Active"
         },
-        "FIdCoast": {
+        "FIModCoast": {
           "stratFilterCondition":"Active || Very-Active"
         },
-        "FIPermaSwap":{
+        "FISingleMS":{
           "stratFilterCondition":"(Idle || Semi-Idle) && rho >= 1000 && rho <= 1300"
         },
-        "FIPermaSwapCoast":{
+        "FISingleMSCoast":{
           "stratFilterCondition":"Semi-Idle && rho >= 1000 && rho <= 1300"
         },
-        "FIdPermaSwap":{
+        "FIModSingleMS":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1000 && rho <= 1300"
         },
-        "FIdPermaSwapCoast":{
+        "FIModSingleMSCoast":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1000 && rho <= 1300"
         },
         "FIMS":{
@@ -556,22 +556,22 @@
         "FIMSCoast":{
           "stratFilterCondition":"(Active || Very-Active || rho <= 30) && rho < 950"
         },
-        "FIMSd": {
+        "FIMSMod": {
           "stratFilterCondition":"(Active || Very-Active) && rho < 950"
         },
-        "FIMSdCoast": {
+        "FIMSModCoast": {
           "stratFilterCondition":"(Active || Very-Active) && rho < 950"
         },
-        "FIMSPermaSwap":{
+        "FIMSSingleMS":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1025 && rho < 1150"
         },
-        "FIMSPermaSwapCoast":{
+        "FIMSSingleMSCoast":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1025 && rho < 1150"
         },
-        "FIMSdPermaSwap":{
+        "FIMSModSingleMS":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1025 && rho < 1150"
         },
-        "FIMSdPermaSwapCoast":{
+        "FIMSModSingleMSCoast":{
           "stratFilterCondition":"(Active || Very-Active) && rho >= 1025 && rho < 1150"
         }
       }}

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -140,27 +140,27 @@
     "T4": {
       "tauFactor": 1,
       "strats": {
-        "T4C3dcoast2": {
+        "T4C3dcoast": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 240"
         },
         "T4C3d": {
           "stratFilterCondition": "false"
         },
-        "T4C3coast2": {
+        "T4C3coast": {
           "stratFilterCondition": "Semi-Idle && rho >= 240"
         },
         "T4C3": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho > 200"
         },
-        "T4C3dC12rcv": {
+        "T4C3dStopC12": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 175 && (lastStrat !== \"T4C3d66\" || rho < 225)",
           "forcedCondition": "rho >= 75"
         },
-        "T4C356dC12rcv": {
+        "T4NoC4dStopC12": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 175 && rho < 300",
           "forcedCondition": "rho >= 75"
         },
-        "T4C456dC12rcvMS": {
+        "T4MSNoC3dStopC12": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 75 && rho < 200",
           "forcedCondition": "rho >= 25"
         },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -200,7 +200,7 @@
           "stratFilterCondition": "Idle || rho < 25"
         },
         "T5Idle": {
-          "stratFilterCondition": "Semi-Idle"
+          "stratFilterCondition": "false"
         },
         "T5IdleCoast": {
           "stratFilterCondition": "Semi-Idle"

--- a/src/Theories/CTs/BaP.ts
+++ b/src/Theories/CTs/BaP.ts
@@ -205,7 +205,6 @@ class bapSim extends theoryClass<theory> {
       this.pubConditions.push(() => this.maxRho >= this.forcedPubRho);
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestones();

--- a/src/Theories/CTs/BaP.ts
+++ b/src/Theories/CTs/BaP.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/BaP.ts
+++ b/src/Theories/CTs/BaP.ts
@@ -33,21 +33,12 @@ class bapSim extends theoryClass<theory> {
   getBuyingConditions(): conditionFunction[] {
     const idlestrat = new Array(12).fill(true)
     const semiidlestrat = new Array(12).fill(() => this.maxRho < this.getNextCoast() - l10(25));
-    const activestrat = [
-      true,
-      () => this.variables[1].cost + l10(0.5 * this.variables[0].level % 64) < this.variables[2].cost 
-        && (this.milestones[0] > 0 || this.variables[1].level < 65),
-      ...new Array(10).fill(true)
-    ]
 
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       BaP: idlestrat,
       BaPcoast: semiidlestrat,
-      BaPAI: [],
-      BaPAIMS: [],
-      BaPAIMS2: [],
-      BaPd: activestrat,
-      BaPdMS: activestrat,
+      BaPModBurstC1: [],
+      BaPMSModBurstC1: []
     };
 
     return toCallables(conditions[this.strat]);
@@ -86,7 +77,7 @@ class bapSim extends theoryClass<theory> {
     const apriority = [0, 1, 2, 3, 4];
     const qpriority = [0, 1, 3, 2, 4];
 
-    if (this.strat == "BaPdMS" || this.strat == "BaPAIMS")
+    if (this.strat == "BaPMSModBurstC1")
     {
       const tm300 = this.t % 300;
       if (tm300 < 100) return qpriority;
@@ -279,7 +270,7 @@ class bapSim extends theoryClass<theory> {
     return weights;
   }
   buyVariables() {
-    if (!this.strat.includes("AI")) super.buyVariables();
+    if (!this.strat.includes("BurstC1")) super.buyVariables();
     else super.buyVariablesWeight();
   }
 }

--- a/src/Theories/CTs/CSR2.ts
+++ b/src/Theories/CTs/CSR2.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { LinearValue, ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/CSR2.ts
+++ b/src/Theories/CTs/CSR2.ts
@@ -221,7 +221,6 @@ class csr2Sim extends theoryClass<theory> {
       this.recursionValue = [sim.bestCoast[1], 1];
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (

--- a/src/Theories/CTs/CSR2.ts
+++ b/src/Theories/CTs/CSR2.ts
@@ -2,18 +2,41 @@ import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { LinearValue, ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost } from '../../Utils/cost';
-import { add, l10, subtract, getBestResult, getLastLevel, toCallables } from "../../Utils/helpers";
+import { add, l10, subtract, getBestResult, getLastLevel, toCallables, newtonMax, logToExp } from "../../Utils/helpers";
 import pubtable from "./helpers/CSR2pubtable.json" with { type: "json" };
 
 export default async function csr2(data: theoryData): Promise<simResult> {
+  if (data.strat !== "CSR2") {
+    const sim1 = new csr2Sim(data);
+    const res1 = await sim1.simulate();
+
+    if (sim1.forcedPubRho !== Infinity) {
+      return res1;
+    }
+    else {
+      const sim2 = new csr2Sim(data);
+      sim2.variables.forEach((v, i) => 
+        v.setOriginalCap(getLastLevel(v.name, res1.boughtVars) || sim1.variables[i].level));
+
+      sim2.variables[0].configureCap(4);
+      sim2.variables[1].configureCap(1);
+      sim2.variables[2].configureCap(4);
+      sim2.variables[3].configureCap(1);
+      sim2.variables[4].configureCap(1);
+
+      const res2 = await sim2.simulate();
+      return res2;
+    }
+  }
+
   const sim = new csr2Sim(data);
-  const res = await sim.simulate(data);
+  const res = await sim.simulate();
   return res;
 }
 
 type theory = "CSR2";
 
-type pubTable = {[key: string]: number};
+type PubTableType = {[key: string]: number};
 const lowboundsActive = [0.65, 0.15, 0.85, 0, 0];
 const highboundsActive = [1.45, 0.5, 1.8, 1.2, 1.2];
 
@@ -21,50 +44,58 @@ const lowboundsPassive = [1, 0.15, 1.35, 0, 0];
 const highboundsPassive = [3.85, 0.5, 3.8, 1.2, 1.2];
 
 class csr2Sim extends theoryClass<theory> {
-  recursionValue: number[];
-  bestCoast: number[];
   q: number;
   updateError_flag: boolean;
   error: number;
 
   forcedPubRho: number;
-  coasting: boolean[];
   bestRes: simResult | null;
   doContinuityFork: boolean;
   lowbounds: number[];
   highbounds: number[];
 
+  tauHForSwap: number;
+  swapQ?: number;
+
   getBuyingConditions(): conditionFunction[] {
-    const idlestrat = [true, true, true, true, true];
-    const activeStrat = [
+    const idleStrat = [true, true, true, true, true];
+    const coastingStrat = new Array(5).map((_, i) => () => this.variables[i].shouldBuy);
+    const dStrat = [
         () =>
-          this.variables[0].cost + l10(7 + (this.variables[0].level % 10)) <
-          Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
-        true,
+          this.variables[0].shouldBuy
+          && this.variables[0].cost + 1 <
+            Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
+        () => this.variables[1].shouldBuy,
         () =>
-          this.variables[2].cost + l10(15 + (this.variables[2].level % 10)) <
-          Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
-        true,
-        true,
+          this.variables[2].shouldBuy
+          && this.variables[2].cost + 1 <
+            Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
+        () => this.variables[3].shouldBuy,
+        () => this.variables[4].shouldBuy,
       ];
-    const activeXLstrat = [
+    const modStrat = [
         () =>
-          this.variables[0].cost + l10(7 + (this.variables[0].level % 10)) <
-          Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
-        () => this.variables[1].cost + l10(1.8) < this.variables[4].cost,
+          this.variables[0].shouldBuy
+          && this.variables[0].cost + l10(7 + (this.variables[0].level % 10)) <
+            Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
+        () => 
+          this.variables[1].shouldBuy 
+          && this.variables[1].cost + l10(1.8) < this.variables[4].cost,
         () =>
-          this.variables[2].cost + l10(15 + (this.variables[2].level % 10)) <
-          Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
-        () => this.variables[3].cost + l10(1.3) < this.variables[4].cost,
-        true,
+          this.variables[2].shouldBuy
+          && this.variables[2].cost + l10(15 + (this.variables[2].level % 10)) <
+            Math.min(this.variables[1].cost, this.variables[3].cost, this.variables[4].cost),
+        () => this.variables[3].shouldBuy
+          && this.variables[3].cost + l10(1.3) < this.variables[4].cost,
+        () => this.variables[4].shouldBuy,
       ];
 
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
-      CSR2: idlestrat,
-      CSR2PT: idlestrat,
-      CSR2d: activeStrat,
-      CSR2XL: activeXLstrat,
-      CSR2XLPT: activeXLstrat
+      CSR2: idleStrat,
+      CSR2PT: coastingStrat,
+      CSR2d: dStrat,
+      CSR2Mod: modStrat,
+      CSR2MSMod: modStrat
     };
     return toCallables(conditions[this.strat]);
   }
@@ -85,12 +116,27 @@ class csr2Sim extends theoryClass<theory> {
     const c2priority = [1, 2, 0];
     const q1priority = [0, 1, 2];
 
-    if (this.lastPub < 500 && this.strat === "CSR2XL") {
+    if (this.lastPub < 500 && this.strat === "CSR2MSMod") {
       let msCond = 0;
       if (this.lastPub > 45) msCond = 4;
       if (this.lastPub > 80) msCond = 8;
       if (this.lastPub > 115) msCond = 20;
       if (this.lastPub > 220) msCond = 40;
+
+      if (this.tauHForSwap === Infinity) return q1priority;
+      if (this.variables.every((v) => !v.shouldBuy)) {
+        const currentTauHForSwap = this.calculateTauHForSwap();
+        console.log(currentTauHForSwap);
+        if (currentTauHForSwap < this.tauHForSwap) {
+          this.tauHForSwap = Infinity;
+          this.swapQ = this.q;
+          return q1priority;
+        }
+        else {
+          this.tauHForSwap = currentTauHForSwap;
+        }
+      }
+
       if (
         (
           (
@@ -100,7 +146,6 @@ class csr2Sim extends theoryClass<theory> {
           )
           && this.rho.value < Math.min(this.variables[3].cost, this.variables[4].cost)
         )
-        || this.t > this.recursionValue[0]
       ) {
         return q1priority;
       } else return c2priority;
@@ -108,46 +153,30 @@ class csr2Sim extends theoryClass<theory> {
 
     return c2priority;
   }
+  calculateTauHForSwap(): number {
+    const oldMilestones = this.milestones
+    this.updateMilestones([0, 1, 2]);
+
+    const vq1 = this.variables[0].value * (1 + 0.05 * this.milestones[0]);
+    const vc2 = this.milestones[1] > 0 ? this.variables[4].value * (1 + 0.5 * this.milestones[2]) : 0;
+    const rhodot_c = this.totMult + vq1 + this.variables[1].value;
+    const qdot = this.totMult + this.variables[2].value + vc2 + this.error;
+
+    this.milestones = oldMilestones;
+
+    let tauHFunc = (t: number) => 
+      this.tauFactor * (add(
+        this.rho.value, 
+        rhodot_c + add(this.q, qdot + l10(t * 0.75)) + l10(t * 1.5)
+      ) 
+        - this.lastPub) / (t / 3600);
+
+    return newtonMax(this.t, tauHFunc);
+  }
   updateError(n: number) {
     const root8 = Math.sqrt(8)
     const root8p3 = root8 + 3;
     this.error = (n%2 == 0 ? subtract(n*l10(root8p3), 0) : add(n*l10(root8p3), 0)) - l10(root8);
-  }
-  searchCoast(rhodot: number) {
-    if (this.curMult > 0.7) {
-      let i = getCoastLen(this.lastPub);
-      const maxMulti = ((this.totMult + l10(4) + l10(200)) / 2.203) * 10;
-      const s = () => {
-        const endRho = add(
-          this.rho.value,
-          rhodot +
-            this.variables[0].value * (this.maxRho >= 10 ? (this.maxRho >= 45 ? (this.maxRho >= 80 ? 1.15 : 1.1) : 1.05) : 1) +
-            l10(i * 1.5)
-        );
-        const endTauH = (Math.min(maxMulti, endRho) - this.lastPub) / ((this.t + i) / 3600);
-        if (this.bestCoast[0] < endTauH) {
-          this.bestCoast[0] = endTauH;
-          this.bestCoast[1] = this.t;
-        }
-      };
-      if (this.lastPub < 500) {
-        s();
-        i = i * 0.8;
-        s();
-        i = i / 0.8 ** 2;
-        s();
-      } else {
-        rhodot = this.totMult + this.variables[0].value * (1 + 0.05 * this.milestones[0]) + this.variables[1].value + this.q;
-        const qdot = this.totMult + this.variables[2].value + this.variables[4].value * 1.15 + this.error;
-        const avgQ = add(this.q + l10(2), qdot + l10(i * 1.5)) - l10(2);
-        const endRho = add(this.rho.value, rhodot - this.q + avgQ + l10(i * 1.5));
-        const endTauH = (endRho - this.lastPub) / ((this.t + i) / 3600);
-        if (this.bestCoast[0] < endTauH && endRho < maxMulti) {
-          this.bestCoast[0] = endTauH;
-          this.bestCoast[1] = this.t;
-        }
-      }
-    }
   }
   constructor(data: theoryData) {
     super(data);
@@ -164,15 +193,12 @@ class csr2Sim extends theoryClass<theory> {
       new Variable({ name: "n",  cost: new ExponentialCost(50, 2 ** (Math.log2(256) * 3.346)), valueScaling: new LinearValue(1, 1)}),
       new Variable({ name: "c2", cost: new ExponentialCost(1e3, 10 ** 5.65), valueScaling: new ExponentialValue(2) }),
     ];
-
-    this.recursionValue = <number[]>data.recursionValue ?? [Infinity, 0];
-    this.bestCoast = [0, 0];
+    this.tauHForSwap = 0;
 
     this.forcedPubRho = Infinity;
-    this.coasting = new Array(this.variables.length).fill(false);
     this.bestRes = null;
     this.doContinuityFork = true;
-    if(this.strat.includes("XL")) {
+    if(this.strat.includes("Mod")) {
         this.lowbounds = lowboundsActive;
         this.highbounds = highboundsActive;
     }
@@ -180,8 +206,8 @@ class csr2Sim extends theoryClass<theory> {
         this.lowbounds = lowboundsPassive;
         this.highbounds = highboundsPassive;
     }
-    if (this.strat.includes("PT") && this.lastPub >= 500 && this.lastPub < 1499.5) {
-      let newpubtable: pubTable = pubtable.csr2data;
+    if (this.strat !== "CSR2" && this.lastPub >= 500 && this.lastPub < 1499.5) {
+      let newpubtable: PubTableType = pubtable.csr2data;
       let pubseek = Math.round(this.lastPub * 16);
       this.forcedPubRho = newpubtable[pubseek.toString()] / 16;
       if (this.forcedPubRho === undefined) this.forcedPubRho = Infinity;
@@ -194,66 +220,59 @@ class csr2Sim extends theoryClass<theory> {
     super.copyFrom(other);
 
     this.milestones = [...other.milestones];
-    this.recursionValue = [...other.recursionValue];
-    this.bestCoast = [...other.bestCoast];
     this.curMult = other.curMult;
     this.q = other.q;
     this.updateError_flag = other.updateError_flag;
     this.error = other.error;
 
     this.forcedPubRho = other.forcedPubRho;
-    this.coasting = [...other.coasting];
   }
   copy(): csr2Sim {
     let newsim = new csr2Sim(super.getDataForCopy());
     newsim.copyFrom(this);
     return newsim;
   }
-  async simulate(data: theoryData): Promise<simResult> {
+  async simulate(): Promise<simResult> {
+    //console.log("Start CSR2 sim");
     if (this.forcedPubRho != Infinity) {
       this.pubConditions.push(() => this.maxRho >= this.forcedPubRho);
-    }
-    if (this.lastPub >= 10 && (data.recursionValue === null || data.recursionValue === undefined) && this.strat === "CSR2XL") {
-      data.recursionValue = [Infinity, 0];
-      const sim = new csr2Sim(data);
-      await sim.simulate(data);
-      this.recursionValue = [sim.bestCoast[1], 1];
     }
     while (!this.endSimulation()) {
       this.tick();
       this.updateSimStatus();
-      if (
-        (this.recursionValue !== null && this.recursionValue !== undefined && this.t < this.recursionValue[0])
-        || this.curMult < 0.7
-        || this.recursionValue[1] === 0
-      ) await this.buyVariablesFork();
+      // Do variable forks
+      for (let i = 0; i < this.variables.length; i++) {
+        let v = this.variables[i];
+        if (v.shouldFork && v.cost <= this.rho.value) {
+          await this.doForkVariable(i);
+          this.bestRes = getBestResult(this.bestRes, this.bestForkRes);
+        }
+      }
+      
+      this.buyVariables();
       if (this.lastPub < 500) this.updateMilestones();
+      // Continuity fork for pub tables
       if (this.forcedPubRho == 1500 && this.maxRho >= 1497 && this.doContinuityFork) {
         this.doContinuityFork = false;
         const fork = this.copy();
         fork.forcedPubRho = Infinity;
-        const res = await fork.simulate(this.getDataForCopy());
+        const res = await fork.simulate();
         if (res.pubRho > 1500) {
           this.bestRes = getBestResult(this.bestRes, res);
         }
       }
     }
-    if (this.recursionValue[1] === 1 || this.strat !== "CSR2XL")
-      this.trimBoughtVars();
+    this.trimBoughtVars();
 
     let stratExtra = " ";
-    if (this.strat === "CSR2XL") {
-      let lastBuy = 0;
-      for (let i = 0; i < this.variables.length; i++) {
-        const costIncs = [5, 128, 16, 2 ** (Math.log2(256) * 3.346), 10 ** 5.65];
-        lastBuy = Math.max(lastBuy, this.variables[i].cost - l10(costIncs[i]));
-      }
-      stratExtra += (10 ** (this.getTotMult(Math.min(lastBuy, this.pubRho)) - this.totMult)).toFixed(2);
-    }
-    if (this.strat.includes("PT")) {
+    if (this.strat !== "CSR2") {
       stratExtra += `q1: ${getLastLevel("q1", this.boughtVars)} q2: ${getLastLevel("q2", this.boughtVars)} c1: ${getLastLevel("c1", this.boughtVars)}`;
     }
+    if (this.swapQ) {
+      stratExtra += " q: " + logToExp(this.swapQ, 1);
+    }
     const result = this.createResult(stratExtra);
+    //console.log("End CSR2 sim");
     return getBestResult(result, this.bestRes);
   }
   tick() {
@@ -267,43 +286,28 @@ class csr2Sim extends theoryClass<theory> {
       this.updateError_flag = false;
     }
 
-    if (this.lastPub < 500) this.searchCoast(this.totMult + this.variables[1].value + this.q);
-
-    const qdot = this.variables[2].value + vc2 + this.error;
-    this.q = add(this.q, this.totMult + l10(this.dt) + qdot);
+    const qdot = this.totMult + this.variables[2].value + vc2 + this.error;
+    this.q = add(this.q, l10(this.dt) + qdot);
     const rhodot = this.totMult + vq1 + this.variables[1].value + this.q;
     this.rho.add(rhodot + l10(this.dt));
   }
-  extraBuyingCondition(id: number): boolean {
-    return !this.coasting[id];
-  }
-  async confirmPurchase(id: number): Promise<boolean> {
-    if (this.forcedPubRho !== Infinity) {
-      if (this.forcedPubRho - this.variables[id].cost <= this.lowbounds[id]) {
-        this.coasting[id] = true;
-        return false;
-      }
-      if (this.forcedPubRho - this.variables[id].cost < this.highbounds[id]) {
-        let fork = this.copy();
-        fork.coasting[id] = true;
-        const forkres = await fork.simulate(super.getDataForCopy());
-        this.bestRes = getBestResult(this.bestRes, forkres);
-      }
-    }
-    return true;
-  }
   onVariablePurchased(id: number): void {
     if (id > 2) this.updateError_flag = true;
-  }
-  onAnyVariablePurchased(): void {
-    if (this.strat === "CSR2XL") this.searchCoast(this.totMult + this.variables[1].value + this.q);
+    if (this.strat !== "CSR2") {
+      if (this.forcedPubRho !== Infinity) {
+        if (this.forcedPubRho - this.variables[id].cost <= this.lowbounds[id]) {
+          this.variables[id].stopBuying();
+        }
+        else if (this.forcedPubRho - this.variables[id].cost < this.highbounds[id]) {
+          this.variables[id].shouldFork = true;
+        }
+      }
+      else if (this.variables[id].coastingCapReached()) {
+        if (this.variables[id].level < this.variables[id].originalCap) 
+          this.variables[id].shouldFork = true;
+        else this.variables[id].stopBuying();
+      }
+    }
   }
 }
 
-function getCoastLen(r: number) {
-  if (r < 45) return r ** 2.1 / 10;
-  if (r < 80) return r ** 2.22 / 40;
-  if (r < 220) return r ** 2.7 / 3.3e4 + 40;
-  if (r < 500) return r ** 2.8 / 9.2e4 + 40;
-  return 1.5 ** (r ** 0.8475 / 20) * 5;
-}

--- a/src/Theories/CTs/EF.ts
+++ b/src/Theories/CTs/EF.ts
@@ -7,7 +7,7 @@ import { add, l10, getLastLevel, getBestResult, binaryInsertionSearch, toCallabl
 import pubtable from "./helpers/EFpubtable.json" with { type: "json" };
 
 export default async function ef(data: theoryData): Promise<simResult> {
-  if (data.strat !== "EFPlay") {
+  if (data.strat !== "EFModStage") {
     const sim = new efSim(data);
     const res = await sim.simulate();
     return res;
@@ -89,7 +89,7 @@ class efSim extends theoryClass<theory> {
         /*a2*/ true,
         /*a3*/ true,
       ],
-      EFPlay: [
+      EFModStage: [
         true,
         () => this.variables[1].cost + l10(10 + (this.variables[1].level % 10)) < this.variables[2].cost,
         true,

--- a/src/Theories/CTs/EF.ts
+++ b/src/Theories/CTs/EF.ts
@@ -14,7 +14,7 @@ export default async function ef(data: theoryData): Promise<simResult> {
   }
   const initialSim = new efSim({
     ...data,
-    strat: "EFAI"
+    strat: "EFMod"
   });
   const initialRes = await initialSim.simulate();
   const sim = new efSim(data);
@@ -52,7 +52,7 @@ class efSim extends theoryClass<theory> {
   getBuyingConditions() {
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       EF: new Array(10).fill(true),
-      EFSnax: [
+      EFStopQ1BXCX: [
         true,
         () => this.curMult < 1,
         true,
@@ -76,7 +76,7 @@ class efSim extends theoryClass<theory> {
         true,
         true,
       ],
-      EFAI: [
+      EFMod: [
         /*tdot*/ true,
         /*q1*/ () => this.variables[1].cost + l10(10 + (this.variables[1].level % 10)) < this.variables[2].cost,
         /*q2*/ true,

--- a/src/Theories/CTs/EF.ts
+++ b/src/Theories/CTs/EF.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Currency from "../../Utils/currency";
 import Variable from "../../Utils/variable";

--- a/src/Theories/CTs/EF.ts
+++ b/src/Theories/CTs/EF.ts
@@ -245,7 +245,6 @@ class efSim extends theoryClass<theory> {
       this.pubConditions.push(() => this.maxRho >= this.forcedPubRho);
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       let prev_nextMilestoneCost = this.nextMilestoneCost;

--- a/src/Theories/CTs/FI.ts
+++ b/src/Theories/CTs/FI.ts
@@ -246,7 +246,6 @@ class fiSim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestones();

--- a/src/Theories/CTs/FI.ts
+++ b/src/Theories/CTs/FI.ts
@@ -116,7 +116,7 @@ class fiSim extends theoryClass<theory> {
 
     let available_fx = binaryInsertionSearch([100, 450, 1050], rho);
     const avaliable_lambda = binaryInsertionSearch([350, 750], rho);
-    const use_fx_level3 = this.strat.includes("PermaSwap") ? this.maxRho >= 1076 : rho >= 1150;
+    const use_fx_level3 = this.strat.includes("SingleMS") ? this.maxRho >= 1076 : rho >= 1150;
     if (!use_fx_level3) available_fx = Math.min(available_fx, 2);
     this.milestonesMax = [1, 1, 3, 1, 1, available_fx, avaliable_lambda];
 
@@ -125,7 +125,7 @@ class fiSim extends theoryClass<theory> {
     const qf = q1m23 < 5 ? 4 : q1m23 < 10 ? 3 : q1m23 < 20 ? 2.5 : 2;
     const qpriority = [0, 1, 5, 6, 2, 3, 4];
     const rhopriority = [0, 1, 5, 6, 3, 4, 2];
-    if (this.strat.includes("MS") && q1mn_points > 0 && q1mn_points < 5 && this.msstate > 0) {
+    if (this.strat.includes("FIMS") && q1mn_points > 0 && q1mn_points < 5 && this.msstate > 0) {
       if (this.msstate == 1) // start q build
       {
         this.msstate = 2;

--- a/src/Theories/CTs/FI.ts
+++ b/src/Theories/CTs/FI.ts
@@ -79,20 +79,20 @@ class fiSim extends theoryClass<theory> {
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       FI: idleStrat,
       FICoast: idleCoastStrat,
-      FId: activeStrat2,
-      FIdCoast: activeCoastStrat2,
-      FIPermaSwap: idleStrat,
-      FIPermaSwapCoast: idleCoastStrat,
-      FIdPermaSwap: activeStrat2,
-      FIdPermaSwapCoast: activeCoastStrat2,
+      FIMod: activeStrat2,
+      FIModCoast: activeCoastStrat2,
+      FISingleMS: idleStrat,
+      FISingleMSCoast: idleCoastStrat,
+      FIModSingleMS: activeStrat2,
+      FIModSingleMSCoast: activeCoastStrat2,
       FIMS: idleStrat,
       FIMSCoast: idleCoastStrat,
-      FIMSd: activeStrat2,
-      FIMSdCoast: activeCoastStrat2,
-      FIMSPermaSwap: idleStrat,
-      FIMSPermaSwapCoast: idleCoastStrat,
-      FIMSdPermaSwap: activeStrat2,
-      FIMSdPermaSwapCoast: activeCoastStrat2
+      FIMSMod: activeStrat2,
+      FIMSModCoast: activeCoastStrat2,
+      FIMSSingleMS: idleStrat,
+      FIMSSingleMSCoast: idleCoastStrat,
+      FIMSModSingleMS: activeStrat2,
+      FIMSModSingleMSCoast: activeCoastStrat2
     };
     return toCallables(conditions[this.strat]);
   }

--- a/src/Theories/CTs/FI.ts
+++ b/src/Theories/CTs/FI.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/FP.ts
+++ b/src/Theories/CTs/FP.ts
@@ -239,7 +239,6 @@ class fpSim extends theoryClass<theory> {
       this.simEndConditions.push(() => this.curMult > 10000)
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestones();

--- a/src/Theories/CTs/FP.ts
+++ b/src/Theories/CTs/FP.ts
@@ -111,10 +111,10 @@ class fpSim extends theoryClass<theory> {
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       FP: idleStrat,
       FPcoast: idleStrat,
-      FPd: activeStrat,
-      FPdMS: activeStrat,
-      FPmodBurstC1: activeBurstStrat,
-      FPmodBurstC1MS: activeBurstStrat
+      FPMod: activeStrat,
+      FPMSMod: activeStrat,
+      FPModBurstC1: activeBurstStrat,
+      FPMSModBurstC1: activeBurstStrat
     };
     return toCallables(conditions[this.strat]);
   }

--- a/src/Theories/CTs/FP.ts
+++ b/src/Theories/CTs/FP.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue, BaseValue } from "../../Utils/value";

--- a/src/Theories/CTs/MF.ts
+++ b/src/Theories/CTs/MF.ts
@@ -590,7 +590,6 @@ class mfSim extends theoryClass<theory> {
 
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestonesNoMS();

--- a/src/Theories/CTs/MF.ts
+++ b/src/Theories/CTs/MF.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/RZ.ts
+++ b/src/Theories/CTs/RZ.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Currency from "../../Utils/currency";
 import Variable from "../../Utils/variable";

--- a/src/Theories/CTs/RZ.ts
+++ b/src/Theories/CTs/RZ.ts
@@ -215,7 +215,7 @@ export default async function rz(data: theoryData) {
         }
         return bestSimRes2;
     }
-    else if(data.strat.includes("MS") && data.rho <= 400 && data.rho >= 10) {
+    else if(data.strat.includes("SingleMS") && data.rho <= 400 && data.rho >= 10) {
         const swapPointDeltas = [0, -1, -2, -3, -4, -5, -6];
         let normalRets = [];
         for(let i = 0; i < swapPointDeltas.length; i++) {
@@ -354,9 +354,9 @@ class rzSim extends theoryClass<theory> {
             RZdBH: activeStrat,
             RZdBHLong: activeStrat,
             RZdBHRewind: activeStrat,
-            RZSpiralswap: activeStrat,
-            RZdMS: activeStrat,
-            RZMS: semiPassiveStrat,
+            RZdSpiralMS: activeStrat,
+            RZdSingleMS: activeStrat,
+            RZSingleMS: semiPassiveStrat,
             // RZnoB: [true, true, false, true, true, false, false],
         };
         return toCallables(conditions[this.strat]);
@@ -380,11 +380,11 @@ class rzSim extends theoryClass<theory> {
         const originPriority = [1, 0, 2, 3];
         const peripheryPriority = [1, 2, 0, 3];
 
-        if (this.strat === "RZSpiralswap" && stage >= 2 && stage <= 4)
+        if (this.strat === "RZdSpiralMS" && stage >= 2 && stage <= 4)
         {
             return this.zTerm > 1 ? peripheryPriority : originPriority;
         }
-        else if ((this.strat === "RZMS" || this.strat === "RZdMS") && stage >= 2 && stage <= 4)
+        else if ((this.strat === "RZSingleMS" || this.strat === "RZdSingleMS") && stage >= 2 && stage <= 4)
         {
             return this.maxRho > this.lastPub + this.swapPointDelta ? originPriority : peripheryPriority;
         }
@@ -609,7 +609,7 @@ class rzSim extends theoryClass<theory> {
         {
             stratExtra += ` t=${this.bhAtRecovery ? this.t_var.toFixed(2) : this.targetZero.toFixed(2)}`
         }
-        if (this.strat.includes("MS") && this.swapPointDelta != 0) {
+        if (this.strat.includes("SingleMS") && this.swapPointDelta != 0) {
             stratExtra += ` swap:${logToExp(this.lastPub + this.swapPointDelta, 2)}`
         }
         if (this.normalPubRho != -1) {

--- a/src/Theories/CTs/RZ.ts
+++ b/src/Theories/CTs/RZ.ts
@@ -580,7 +580,6 @@ class rzSim extends theoryClass<theory> {
         const BHStrats = new Set(["RZBH", "RZdBH", "RZBHLong", "RZdBHLong", "RZdBHRewind"]);
         try {
             while (!this.endSimulation()) {
-                if (!global.simulating) break;
                 // Prevent lookup table from retrieving values from wrong sim settings
                 if (!this.ticks && (this.dt !== lookups.prevDt || this.ddt !== lookups.prevDdt)) {
                     lookups.prevDt = this.dt;

--- a/src/Theories/CTs/SL.ts
+++ b/src/Theories/CTs/SL.ts
@@ -50,19 +50,19 @@ class slSim extends theoryClass<theory> {
         () => this.variables[2].shouldBuy,
         () => this.variables[3].shouldBuy
       ],
-      SLdCoast: [
+      SLModCoast: [
         () => this.variables[0].shouldBuy && this.variables[0].cost + l10(2 * (this.variables[0].level % 3) + 0.0001) < this.variables[1].cost,
         () => this.variables[1].shouldBuy,
         () => this.variables[2].shouldBuy && this.variables[2].cost + l10(this.variables[2].cost % 4) < this.variables[3].cost,
         () => this.variables[3].shouldBuy,
       ],
-      SLMS: [
+      SLMSMC: [
         () => this.curMult < 4,
         () => this.curMult < 4,
         () => this.curMult < 7.5,
         () => this.curMult < 7.5
       ],
-      SLMSd: [
+      SLMSModMC: [
         () => this.curMult < 4 && this.variables[0].cost + l10(2 * (this.variables[0].level % 3) + 0.0001) < this.variables[1].cost,
         () => this.curMult < 4,
         () => this.curMult < 7.5 && this.variables[2].cost + l10(this.variables[2].cost % 4) < this.variables[3].cost,

--- a/src/Theories/CTs/SL.ts
+++ b/src/Theories/CTs/SL.ts
@@ -214,7 +214,6 @@ class slSim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 300) this.updateMilestones();

--- a/src/Theories/CTs/SL.ts
+++ b/src/Theories/CTs/SL.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/SL.ts
+++ b/src/Theories/CTs/SL.ts
@@ -11,79 +11,25 @@ export default async function sl(data: theoryData): Promise<simResult> {
     res = await sim.simulate();
   }
   else {
-    let data2: theoryData = JSON.parse(JSON.stringify(data));
-    if(data2.strat == "SLCoast") {
-      data2.strat = "SLStopA";
-    }
-    else if(data.strat == "SLdCoast") {
-      data2.strat = "SLStopAd";
-    }
-    const sim1 = new slSim(data2);
-    const res1 = await sim1.simulate();
-    const lastA1 = getLastLevel("a1", res1.boughtVars);
-    const lastA2 = getLastLevel("a2", res1.boughtVars);
-    const lastB1 = getLastLevel("b1", res1.boughtVars);
-    const lastB2 = getLastLevel("b2", res1.boughtVars);
-    const sim2 = new slSim(data);
+    const initialSim = new slSim(data);
+    const initialRes = await initialSim.simulate();
+    const lastA1 = getLastLevel("a1", initialRes.boughtVars);
+    const lastA2 = getLastLevel("a2", initialRes.boughtVars);
+    const lastB1 = getLastLevel("b1", initialRes.boughtVars);
+    const lastB2 = getLastLevel("b2", initialRes.boughtVars);
+    const sim = new slSim(data);
 
-    sim2.variables[0].setOriginalCap(lastA1);
-    sim2.variables[1].setOriginalCap(lastA2);
-    sim2.variables[2].setOriginalCap(lastB1);
-    sim2.variables[3].setOriginalCap(lastB2);
+    sim.variables[0].setOriginalCap(lastA1);
+    sim.variables[1].setOriginalCap(lastA2);
+    sim.variables[2].setOriginalCap(lastB1);
+    sim.variables[3].setOriginalCap(lastB2);
 
-    if(data.strat == "SLCoast") {
-      // These are based on sim results:
-      if (data.rho <= 10) {
-        sim2.variables[0].configureCap(5);
-      } else if (data.rho <= 110) {
-        sim2.variables[0].configureCap(4);
-      } else if (data.rho <= 200) {
-        sim2.variables[0].configureCap(3);
-      } else {
-        sim2.variables[0].configureCap(2);
-      }
+    sim.variables[0].configureCap(8);
+    sim.variables[1].configureCap(3);
+    sim.variables[2].configureCap(3);
+    sim.variables[3].configureCap(2);
 
-      sim2.variables[1].configureCap(1);
-
-      if (data.rho <= 50) {
-        sim2.variables[2].configureCap(3);
-      } else if (data.rho <= 100) {
-        sim2.variables[2].configureCap(2);
-      } else {
-        sim2.variables[2].configureCap(1);
-      }
-
-      if (data.rho <= 150 || data.rho >= 1400) {
-        sim2.variables[3].configureCap(1);
-      } else {
-        sim2.variables[3].configureCap(0);
-      }
-    }
-    else if(data.strat == "SLdCoast") {
-      if (data.rho <= 110) {
-        sim2.variables[0].configureCap(4);
-      } else if (data.rho <= 220) {
-        sim2.variables[0].configureCap(3);
-      } else {
-        sim2.variables[0].configureCap(2);
-      }
-      sim2.variables[1].configureCap(1);
-
-      if (data.rho <= 50) {
-        sim2.variables[2].configureCap(3);
-      } else if (data.rho <= 120) {
-        sim2.variables[2].configureCap(2);
-      } else {
-        sim2.variables[2].configureCap(1);
-      }
-
-      if (data.rho <= 120 || data.rho >= 1450) {
-        sim2.variables[3].configureCap(1);
-      } else {
-        sim2.variables[3].configureCap(0);
-      }
-    }
-    res = await sim2.simulate();
+    res = await sim.simulate();
   }
   return res;
 }
@@ -98,23 +44,11 @@ class slSim extends theoryClass<theory> {
   getBuyingConditions(): conditionFunction[] {
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       SL: [true, true, true, true],
-      SLStopA: [
-        () => this.curMult < 4.5,
-        () => this.curMult < 4.5,
-        () => this.curMult < 6,
-        () => this.curMult < 6
-      ],
       SLCoast: [
         () => this.variables[0].shouldBuy,
         () => this.variables[1].shouldBuy,
         () => this.variables[2].shouldBuy,
         () => this.variables[3].shouldBuy
-      ],
-      SLStopAd: [
-        () => this.curMult < 4.5 && this.variables[0].cost + l10(2 * (this.variables[0].level % 3) + 0.0001) < this.variables[1].cost,
-        () => this.curMult < 4.5,
-        () => this.curMult < 6 && this.variables[2].cost + l10(this.variables[2].cost % 4) < this.variables[3].cost,
-        () => this.curMult < 6,
       ],
       SLdCoast: [
         () => this.variables[0].shouldBuy && this.variables[0].cost + l10(2 * (this.variables[0].level % 3) + 0.0001) < this.variables[1].cost,
@@ -264,21 +198,11 @@ class slSim extends theoryClass<theory> {
         this.variables[id].shouldBuy &&
         this.variables[id].coastingCapReached()
     ) {
-      if(this.strat == "SLCoast") {
-        if(this.variables[id].level < this.variables[id].originalCap + (id === 0 ? 4 : 2)) {
-          this.variables[id].shouldFork = true;
-        }
-        else {
-          this.variables[id].stopBuying();
-        }
+      if(this.variables[id].level < this.variables[id].originalCap - (id === 0 ? 3 : 0)) {
+        this.variables[id].shouldFork = true;
       }
       else {
-        if(this.variables[id].level < this.variables[id].originalCap + (id === 0 ? 3 : 2)) {
-          this.variables[id].shouldFork = true;
-        }
-        else {
-          this.variables[id].stopBuying();
-        }
+        this.variables[id].stopBuying();
       }
     }
   }

--- a/src/Theories/CTs/WSP.ts
+++ b/src/Theories/CTs/WSP.ts
@@ -61,7 +61,7 @@ class wspSim extends theoryClass<theory> {
       () => this.lastPub < 450 || this.t < 15,
       true
     ]);
-    const WSPdStopC1CoastQ1 = toCallables([
+    const WSPModCoastQ1 = toCallables([
       () =>
           this.variables[0].shouldBuy && (this.variables[0].cost + l10(6 + (this.variables[0].level % 10)) <
         Math.min(this.variables[1].cost, this.variables[2].cost, this.milestones[1] > 0 ? this.variables[4].cost : Infinity)),
@@ -77,14 +77,14 @@ class wspSim extends theoryClass<theory> {
       WSP: [true, true, true, true, true],
       WSPStopC1: [true, true, true, () => this.lastPub < 450 || this.t < 15, true],
       WSPStopC1Coast: WSPStopC1CoastQ1,
-      WSPPostRecoveryStopC1Coast: [
-        () => this.maxRho <= this.lastPub ? WSPStopC1CoastQ1[0]() : WSPdStopC1CoastQ1[0](),
+      WSPModRcvICoast: [
+        () => this.maxRho <= this.lastPub ? WSPStopC1CoastQ1[0]() : WSPModCoastQ1[0](),
         true,
         true,
-        () => this.maxRho <= this.lastPub ? WSPStopC1CoastQ1[3]() : WSPdStopC1CoastQ1[3](),
+        () => this.maxRho <= this.lastPub ? WSPStopC1CoastQ1[3]() : WSPModCoastQ1[3](),
         true,
       ],
-      WSPdStopC1: [
+      WSPMod: [
         () =>
           this.variables[0].cost + l10(6 + (this.variables[0].level % 10)) <
           Math.min(this.variables[1].cost, this.variables[2].cost, this.milestones[1] > 0 ? this.variables[4].cost : Infinity),
@@ -95,7 +95,7 @@ class wspSim extends theoryClass<theory> {
             Math.min(this.variables[1].cost, this.variables[2].cost, this.milestones[1] > 0 ? this.variables[4].cost : Infinity) || this.t < 15,
         true,
       ],
-      WSPdStopC1Coast: WSPdStopC1CoastQ1
+      WSPModCoast: WSPModCoastQ1
     };
     return toCallables(conditions[this.strat]);
   }

--- a/src/Theories/CTs/WSP.ts
+++ b/src/Theories/CTs/WSP.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/CTs/WSP.ts
+++ b/src/Theories/CTs/WSP.ts
@@ -151,7 +151,6 @@ class wspSim extends theoryClass<theory> {
   }
   async simulate() {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 200) this.updateMilestones();

--- a/src/Theories/T1-T8/T1.ts
+++ b/src/Theories/T1-T8/T1.ts
@@ -204,7 +204,6 @@ class t1Sim extends theoryClass<theory> {
       this.pubConditions.push(() => this.maxRho >= pub);
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 176) this.updateMilestones();

--- a/src/Theories/T1-T8/T1.ts
+++ b/src/Theories/T1-T8/T1.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/T1-T8/T1.ts
+++ b/src/Theories/T1-T8/T1.ts
@@ -3,12 +3,12 @@ import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost } from '../../Utils/cost';
-import { add, l10, logToExp, getR9multiplier, toCallables, getLastLevel, getBestResult } from "../../Utils/helpers";
+import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult } from "../../Utils/helpers";
 
 
 export default async function t1(data: theoryData): Promise<simResult> {
   let res;
-  if (["T1SolarXLII", "T1C34Coast", "T1C4Coast"].includes(data.strat)) {
+  if (["T1ModRatio", "T1C34Coast", "T1C4Coast"].includes(data.strat)) {
     const initialData: theoryData = {...data};
     const initialSim = new t1Sim(initialData);
     initialSim.doCoasting = false;
@@ -22,7 +22,7 @@ export default async function t1(data: theoryData): Promise<simResult> {
     sim.variables[0].setOriginalCap(lastQ1);
     sim.variables[1].setOriginalCap(lastQ2);
     sim.variables[4].setOriginalCap(lastC3);
-    if (data.strat === "T1SolarXLII") {
+    if (data.strat === "T1ModRatio") {
       sim.variables[0].configureCap(5);
     }
     else {
@@ -75,7 +75,7 @@ class t1Sim extends theoryClass<theory> {
     const q1CoastCond = () => this.variables[0].shouldBuy;
     const q2CoastCond = () => this.variables[1].shouldBuy;
     const c3CoastCond = () => this.variables[4].shouldBuy;
-    const T1SolarXLIICoast = [
+    const T1ModRatio = [
       () => // q1
           q1CoastCond() && (this.variables[0].cost + l10(5) <= this.rho.value &&
           this.variables[0].cost + l10(6 + (this.variables[0].level % 10)) <= this.variables[1].cost &&
@@ -109,7 +109,7 @@ class t1Sim extends theoryClass<theory> {
         () => c3CoastCond() && (this.variables[4].cost + l10(this.c3Ratio) < this.rho.value),
         true,
       ],
-      T1SolarXLII: T1SolarXLIICoast
+      T1ModRatio: T1ModRatio
     };
     return toCallables(conditions[this.strat]);
   }
@@ -156,12 +156,12 @@ class t1Sim extends theoryClass<theory> {
   async simulate(): Promise<simResult> {
     const nextc4 = Math.ceil((this.lastPub - 10) / 8) * 8 + 10;
     // New pub cycle
-    if (["T1SolarXLII", "T1C34Coast", "T1C4Coast"].includes(this.strat))
+    if (["T1ModRatio", "T1C34Coast", "T1C4Coast"].includes(this.strat))
     {
       const c4dist = nextc4 - this.lastPub;
       let prevPoint = 0;
       let nextPoint = 0;
-      if (this.strat === "T1SolarXLII") {
+      if (this.strat === "T1ModRatio") {
         if (c4dist > 7.5) {
           prevPoint = nextc4 - 10 + l10(5.5);
           nextPoint = nextc4 - 6 + l10(1.5);

--- a/src/Theories/T1-T8/T1.ts
+++ b/src/Theories/T1-T8/T1.ts
@@ -70,24 +70,11 @@ class t1Sim extends theoryClass<theory> {
   termRatio: number;
   c3Ratio: number;
   doCoasting: boolean;
-  /** This is exclusivery used by T1SolarXLII and T1SolarXLIICoast for legacy purposes */
-  coast: number;
 
   getBuyingConditions(): conditionFunction[] {
     const q1CoastCond = () => this.variables[0].shouldBuy;
     const q2CoastCond = () => this.variables[1].shouldBuy;
     const c3CoastCond = () => this.variables[4].shouldBuy;
-    const T1SolarXLII = [
-      () => // q1
-        this.variables[0].cost + l10(5) <= this.rho.value &&
-        this.variables[0].cost + l10(6 + (this.variables[0].level % 10)) <= this.variables[1].cost &&
-        this.variables[0].cost + l10(15 + (this.variables[0].level % 10)) < (this.milestones[3] > 0 ? this.variables[5].cost : 1000),
-      () => this.variables[1].cost + l10(1.11) < this.rho.value,
-      () => this.variables[2].cost + this.termRatio + 1 <= this.rho.value,
-      () => this.variables[3].cost + this.termRatio <= this.rho.value,
-      () => this.variables[4].cost + l10(this.c3Ratio) < this.rho.value,
-      true,
-    ];
     const T1SolarXLIICoast = [
       () => // q1
           q1CoastCond() && (this.variables[0].cost + l10(5) <= this.rho.value &&
@@ -122,9 +109,7 @@ class t1Sim extends theoryClass<theory> {
         () => c3CoastCond() && (this.variables[4].cost + l10(this.c3Ratio) < this.rho.value),
         true,
       ],
-      T1SolarXLII: T1SolarXLIICoast,
-      T1SolarXLIIOld: T1SolarXLII,
-      T1SolarXLIIOldCoast: T1SolarXLIICoast
+      T1SolarXLII: T1SolarXLIICoast
     };
     return toCallables(conditions[this.strat]);
   }
@@ -158,7 +143,6 @@ class t1Sim extends theoryClass<theory> {
       new Variable({ name: "c3", cost: new ExponentialCost(1e4, 4.5 * Math.log2(10), true), valueScaling: new ExponentialValue(10) }),
       new Variable({ name: "c4", cost: new ExponentialCost(1e10, 8 * Math.log2(10), true), valueScaling: new ExponentialValue(10) }),
     ];
-    this.coast = Infinity;
     this.doCoasting = this.strat.includes("Coast");
     //values of the different terms, so they are accesible for variable buying conditions
     this.term1 = 0;
@@ -171,17 +155,6 @@ class t1Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     const nextc4 = Math.ceil((this.lastPub - 10) / 8) * 8 + 10;
-    // Old pub cycle
-    if (this.strat.includes("Old")) {
-      const pub =
-          nextc4 - this.lastPub < 3 ? nextc4 + 2
-        : nextc4 - this.lastPub < 5 ? nextc4 - 2 + l10(1.5)
-        : nextc4 - 4 + l10(1.4);
-      this.coast = (nextc4 - this.lastPub < 3 ? nextc4 : Math.floor(this.lastPub)) + l10(30);
-      this.coast = Math.max(8 + l10(30), this.coast + Math.floor(pub - this.coast));
-      this.doSimEndConditions = () => false;
-      this.pubConditions.push(() => this.maxRho >= pub);
-    }
     // New pub cycle
     if (["T1SolarXLII", "T1C34Coast", "T1C4Coast"].includes(this.strat))
     {
@@ -235,16 +208,13 @@ class t1Sim extends theoryClass<theory> {
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 176) this.updateMilestones();
-      if (!(this.strat.includes("Old")) || this.rho.value < this.coast) this.buyVariables();
+      this.buyVariables();
       if (this.variables[0].shouldFork) await this.doForkVariable(0);
       if (this.variables[1].shouldFork) await this.doForkVariable(1);
       if (this.variables[4].shouldFork) await this.doForkVariable(4);
     }
     this.trimBoughtVars();
     let stratExtra = "";
-    if (this.strat.includes("Old")) {
-      stratExtra += ` ${this.lastPub < 50 ? "" : logToExp(Math.min(this.pubRho, this.coast), 2)}`;
-    }
     if(this.doCoasting) {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("q1", this.boughtVars));
       stratExtra += this.variables[1].prepareExtraForCap(getLastLevel("q2", this.boughtVars));
@@ -276,7 +246,6 @@ class t1Sim extends theoryClass<theory> {
     this.termRatio = other.termRatio;
     this.c3Ratio = other.c3Ratio;
     this.doCoasting = other.doCoasting;
-    this.coast = other.coast;
   }
   copy() {
     let sim = new t1Sim(this.getDataForCopy());

--- a/src/Theories/T1-T8/T2.ts
+++ b/src/Theories/T1-T8/T2.ts
@@ -8,7 +8,7 @@ import { add, l10, getR9multiplier, toCallables, getBestResult, defaultResult } 
 export default async function t2(data: theoryData): Promise<simResult> {
   let bestSim: t2Sim;
   let bestSimRes: simResult;
-  if(data.strat == "T2Haxolotl") {
+  if(data.strat == "T2dMC") {
     const savedStrat = data.strat;
     data.strat = "T2MC";
     let t2mcRes = await new t2Sim(data).simulate();
@@ -134,7 +134,7 @@ class t2Sim extends theoryClass<theory> {
         () => this.curMult < this.stop3,
         () => this.curMult < this.stop4,
       ],
-      T2Haxolotl: [
+      T2dMC: [
         () => this.curMult < this.stop1,
         () => (this.variables[1].cost + l10(this.haxolotlC1) < getMax(0)) && this.curMult < this.stop2,
         () => (this.variables[2].cost + l10(this.haxolotlC2) < getMax(1)) && this.curMult < this.stop3,
@@ -235,8 +235,8 @@ class t2Sim extends theoryClass<theory> {
       this.buyVariables();
     }
     this.trimBoughtVars();
-    let stratExtra = ["T2MC3", "T2Haxolotl"].includes(this.strat) ? ` 4:${this.stop4} 3:${this.stop3} 2:${this.stop2} 1:${this.stop1}` : "";
-    if(this.strat == "T2Haxolotl") {
+    let stratExtra = ["T2MC3", "T2dMC"].includes(this.strat) ? ` 4:${this.stop4} 3:${this.stop3} 2:${this.stop2} 1:${this.stop1}` : "";
+    if(this.strat == "T2dMC") {
       stratExtra += ` c1:${this.haxolotlC1} c2:${this.haxolotlC2} c3: ${this.haxolotlC3}`;
     }
     return this.createResult(stratExtra);

--- a/src/Theories/T1-T8/T2.ts
+++ b/src/Theories/T1-T8/T2.ts
@@ -228,7 +228,6 @@ class t2Sim extends theoryClass<theory> {
       this.pubConditions.push(() => this.maxRho >= this.targetRho);
     }
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 250) this.updateMilestones();

--- a/src/Theories/T1-T8/T2.ts
+++ b/src/Theories/T1-T8/T2.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/T1-T8/T2.ts
+++ b/src/Theories/T1-T8/T2.ts
@@ -45,13 +45,13 @@ export default async function t2(data: theoryData): Promise<simResult> {
     }
     bestSimRes = bestRes;
   }
-  else if(data.strat == "T2MCAlt2" || data.strat == "T2MCAlt3") {
+  else if(data.strat == "T2MC2" || data.strat == "T2MC3") {
     const savedStrat = data.strat;
     data.strat = "T2MC";
     let res = await new t2Sim(data).simulate();
 
     data.strat = savedStrat;
-    if(savedStrat == "T2MCAlt2") {
+    if(savedStrat == "T2MC2") {
       bestSim = new t2Sim(data);
       bestSim.targetRho = res.pubRho;
       bestSimRes = await bestSim.simulate();
@@ -114,7 +114,7 @@ class t2Sim extends theoryClass<theory> {
         () => this.curMult < 2250,
         () => this.curMult < 1150,
       ],
-      T2MCAlt: [
+      T2MC2: [
         () => this.curMult < 3500,
         () => this.curMult < 2700,
         () => this.curMult < 2050,
@@ -124,17 +124,7 @@ class t2Sim extends theoryClass<theory> {
         () => this.curMult < 2050,
         () => this.curMult < 550,
       ],
-      T2MCAlt2: [
-        () => this.curMult < 3500,
-        () => this.curMult < 2700,
-        () => this.curMult < 2050,
-        () => this.curMult < 550,
-        () => this.curMult < 3500,
-        () => this.curMult < 2700,
-        () => this.curMult < 2050,
-        () => this.curMult < 550,
-      ],
-      T2MCAlt3: [
+      T2MC3: [
         () => this.curMult < this.stop1,
         () => this.curMult < this.stop2,
         () => this.curMult < this.stop3,
@@ -155,7 +145,7 @@ class t2Sim extends theoryClass<theory> {
         () => (this.variables[7].cost + l10(this.haxolotlC3) < getMax(2)) && this.curMult < this.stop4,
       ],
       T2MS: new Array(8).fill(true),
-      T2QS: new Array(8).fill(true),
+      T2SingleMS: new Array(8).fill(true),
     };
     return toCallables(conditions[this.strat]);
   }
@@ -183,7 +173,7 @@ class t2Sim extends theoryClass<theory> {
       else if (tm100 < 60) return [2, 3, 0, 1];
       else if (tm100 < 100) return [1, 0, 2, 3];
     }
-    if (this.strat === "T2QS") {
+    if (this.strat === "T2SingleMS") {
       let coastMulti = Infinity;
       if (this.lastPub > 0) coastMulti = 10;
       if (this.lastPub > 75) coastMulti = 200;
@@ -245,7 +235,7 @@ class t2Sim extends theoryClass<theory> {
       this.buyVariables();
     }
     this.trimBoughtVars();
-    let stratExtra = ["T2MCAlt3", "T2Haxolotl"].includes(this.strat) ? ` 4:${this.stop4} 3:${this.stop3} 2:${this.stop2} 1:${this.stop1}` : "";
+    let stratExtra = ["T2MC3", "T2Haxolotl"].includes(this.strat) ? ` 4:${this.stop4} 3:${this.stop3} 2:${this.stop2} 1:${this.stop1}` : "";
     if(this.strat == "T2Haxolotl") {
       stratExtra += ` c1:${this.haxolotlC1} c2:${this.haxolotlC2} c3: ${this.haxolotlC3}`;
     }

--- a/src/Theories/T1-T8/T3.ts
+++ b/src/Theories/T1-T8/T3.ts
@@ -272,7 +272,6 @@ class t3Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 175) this.updateMilestones();

--- a/src/Theories/T1-T8/T3.ts
+++ b/src/Theories/T1-T8/T3.ts
@@ -37,7 +37,7 @@ class t3Sim extends theoryClass<theory> {
 
   getBuyingConditions(): conditionFunction[] {
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
-      T3Play2: [
+      T3dStage: [
         () => (this.lastPub - this.maxRho > 1 ? this.variables[0].cost + l10(8) < this.variables[9].cost : false),
         () => (this.curMult < 1.2 ? this.variables[1].cost + l10(5) < this.variables[10].cost : this.variables[1].cost + l10(8) < this.variables[4].cost) || this.curMult > 2.4,
         () => (this.curMult < 2.4 ? this.variables[2].cost + l10(8) < this.variables[8].cost : true),
@@ -129,7 +129,7 @@ class t3Sim extends theoryClass<theory> {
         () => this.variables[2].shouldBuy,
         false, true, false, false, true, true, false, true, true
       ],
-      T3noC11C13C21C33d: [
+      T3P2C23C31d: [
         () => this.variables[0].cost + l10(8) < this.variables[9].cost,
         () => this.variables[1].cost + l10(5) < Math.min(this.variables[4].cost, this.variables[7].cost, this.variables[10].cost),
         () => this.variables[2].cost + l10(8) < this.variables[8].cost,
@@ -143,7 +143,7 @@ class t3Sim extends theoryClass<theory> {
         true,
         false,
       ],
-      T3noC11C13C21C33: [true, true, true, false, true, false, false, true, true, true, true, false],
+      T3P2C23C31: [true, true, true, false, true, false, false, true, true, true, true, false],
       T3noC13C33d: [
         () => this.variables[0].cost + l10(10) < Math.min(this.variables[3].cost, this.variables[6].cost, this.variables[9].cost),
         () => this.variables[1].cost + l10(4) < Math.min(this.variables[4].cost, this.variables[7].cost, this.variables[10].cost),

--- a/src/Theories/T1-T8/T3.ts
+++ b/src/Theories/T1-T8/T3.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Currency from "../../Utils/currency";
 import Variable from "../../Utils/variable";

--- a/src/Theories/T1-T8/T3.ts
+++ b/src/Theories/T1-T8/T3.ts
@@ -51,24 +51,7 @@ class t3Sim extends theoryClass<theory> {
         () => (this.curMult < 1.2 ? true : this.curMult < 2.4 ? this.variables[10].cost + l10(8) < this.variables[4].cost : false),
         () => (this.curMult < 1.2 ? this.variables[11].cost + l10(10) < this.variables[8].cost : false),
       ],
-      T3Play: [
-        () => (this.curMult < 2 ? this.variables[0].cost + l10(8) < this.variables[9].cost : false),
-        () => this.curMult < 2 
-          ? this.variables[1].cost + l10(4) < Math.min(this.variables[4].cost, this.variables[10].cost) 
-            && this.variables[1].cost + l10(2) < this.variables[7].cost 
-          : true,
-        () => this.variables[2].cost + l10(8) < this.variables[8].cost && this.variables[2].cost + l10(2) < this.variables[11].cost,
-        false,
-        true,
-        false,
-        false,
-        () => (this.curMult < 2 ? this.variables[7].cost + l10(2) < Math.min(this.variables[4].cost, this.variables[10].cost) : true),
-        true,
-        () => this.curMult < 2,
-        true,
-        () => this.variables[11].cost + l10(4) < this.variables[8].cost,
-      ],
-      T3SnaxCoast: [
+      T3NoC11C13C21StopB1C3XCoast: [
         () => this.curMult < 1,
         () => this.variables[1].shouldBuy,
         () => this.variables[2].shouldBuy,
@@ -82,7 +65,7 @@ class t3Sim extends theoryClass<theory> {
         () => this.curMult < 1,
         () => this.curMult < 1,
       ],
-      T3Snax: [
+      T3NoC11C13C21StopB1C3X: [
         () => this.curMult < 1,
         true,
         true,
@@ -96,7 +79,7 @@ class t3Sim extends theoryClass<theory> {
         () => this.curMult < 1,
         () => this.curMult < 1,
       ],
-      T3SnaxdC12: [
+      T3NoC11C13C21StopB1C3XRcvA: [
         () => this.curMult < 1,
         true,
         true,
@@ -109,20 +92,6 @@ class t3Sim extends theoryClass<theory> {
         () => this.curMult < 1,
         () => this.curMult < 1,
         () => this.curMult < 1,
-      ],
-      T3Snax2: [
-        () => (this.curMult < 1 ? this.variables[0].cost + 1 < this.rho.value : false),
-        () => this.variables[1].cost + l10(3) < this.rho2.value,
-        () => this.variables[2].cost + l10(5) < this.rho3.value,
-        false,
-        () => (this.curMult < 1 ? this.variables[4].cost + 2 < this.rho.value : true),
-        false,
-        false,
-        () => (this.curMult < 1 ? true : this.variables[7].cost + l10(8) < this.rho2.value),
-        true,
-        () => this.curMult < 1,
-        () => this.curMult < 1,
-        () => (this.curMult < 1 ? this.variables[11].cost + 1 < this.rho3.value : false),
       ],
       T3P2C23d: [
         false,

--- a/src/Theories/T1-T8/T4.ts
+++ b/src/Theories/T1-T8/T4.ts
@@ -15,13 +15,13 @@ import {
 
 export default async function t4(data: theoryData): Promise<simResult> {
   let res;
-  if(!data.strat.includes("coast2")) {
+  if(!data.strat.includes("coast")) {
     const sim = new t4Sim(data);
     res = await sim.simulate();
   }
   else {
     let data2: theoryData = JSON.parse(JSON.stringify(data));
-    data2.strat = data2.strat.replace("coast2", "");
+    data2.strat = data2.strat.replace("coast", "");
     const sim1 = new t4Sim(data2);
     const res1 = await sim1.simulate();
     const lastQ1 = getLastLevel("q1", res1.boughtVars);
@@ -63,7 +63,7 @@ class t4Sim extends theoryClass<theory> {
             this.variables[6].cost + l10(10 + (this.variables[6].level % 10)) <= Math.min(this.variables[7].cost, this.variables[2].cost),
         () => this.curMult < 1 || this.variables[7].cost + l10(1.5) <= this.variables[2].cost,
       ],
-      T4C3dcoast2: [
+      T4C3dcoast: [
         false,
         false,
         () => this.variables[2].shouldBuy,
@@ -72,7 +72,7 @@ class t4Sim extends theoryClass<theory> {
             (this.variables[6].cost + l10(10 + (this.variables[6].level % 10)) <= Math.min(this.variables[7].cost, this.variables[2].cost)),
         () => this.variables[7].shouldBuy && (this.curMult < 1 || this.variables[7].cost + l10(1.5) <= this.variables[2].cost),
       ],
-      T4C3coast2: [
+      T4C3coast: [
         false,
         false,
         () => this.variables[2].shouldBuy,
@@ -81,7 +81,7 @@ class t4Sim extends theoryClass<theory> {
         () => this.variables[7].shouldBuy,
       ],
       T4C3: [false, false, true, ...new Array(3).fill(false), true, true],
-      T4C3dC12rcv: [
+      T4C3dStopC12: [
         () => this.variables[0].cost + 1 < this.variables[1].cost && this.maxRho < this.lastPub, 
         () => this.maxRho < this.lastPub, 
         true, 
@@ -89,7 +89,7 @@ class t4Sim extends theoryClass<theory> {
         () => this.variables[6].cost + 1 < this.variables[7].cost, 
         true
       ],
-      T4C356dC12rcv: [
+      T4NoC4dStopC12: [
         () => this.variables[0].cost + 1 < this.variables[1].cost && this.maxRho < this.lastPub, 
         () => this.maxRho < this.lastPub, 
         true, 
@@ -99,7 +99,7 @@ class t4Sim extends theoryClass<theory> {
         () => this.variables[6].cost + 1 < this.variables[7].cost, 
         true
       ],
-      T4C456dC12rcvMS: [
+      T4MSNoC3dStopC12: [
         () => this.variables[0].cost + 1 < this.variables[1].cost && this.maxRho < this.lastPub, 
         () => this.maxRho < this.lastPub, 
         false, 
@@ -139,12 +139,12 @@ class t4Sim extends theoryClass<theory> {
   getMilestonePriority(): number[] {
     switch (this.strat) {
       case "T4C3d": return [2];
-      case "T4C3coast2": return [2];
-      case "T4C3dcoast2": return [2];
+      case "T4C3coast": return [2];
+      case "T4C3dcoast": return [2];
       case "T4C3": return [2];
-      case "T4C3dC12rcv": return [1, 2];
-      case "T4C356dC12rcv": return [1, 2, 0];
-      case "T4C456dC12rcvMS": {
+      case "T4C3dStopC12": return [1, 2];
+      case "T4NoC4dStopC12": return [1, 2, 0];
+      case "T4MSNoC3dStopC12": {
         if (this.maxRho < this.lastPub) return [1, 2, 0]
         else if (this.t % 100 < 50) return [2, 0, 1] 
         else return [0, 2, 1];
@@ -197,7 +197,7 @@ class t4Sim extends theoryClass<theory> {
     }
     this.trimBoughtVars();
     let stratExtra = '';
-    if(this.strat.includes("coast2")) {
+    if(this.strat.includes("coast")) {
       stratExtra = this.variables[6].prepareExtraForCap(getLastLevel("q1", this.boughtVars)) +
           this.variables[7].prepareExtraForCap(getLastLevel("q2", this.boughtVars)) +
           this.variables[2].prepareExtraForCap(getLastLevel("c3", this.boughtVars));
@@ -226,7 +226,7 @@ class t4Sim extends theoryClass<theory> {
   onVariablePurchased(id: number) {
     if(
         [2, 6, 7].includes(id) &&
-        this.strat.includes("coast2") &&
+        this.strat.includes("coast") &&
         this.variables[id].shouldBuy &&
         this.variables[id].coastingCapReached() &&
         // For this strat, there is almost never use to get levels above cap. We can skip simming that for faster sim:

--- a/src/Theories/T1-T8/T4.ts
+++ b/src/Theories/T1-T8/T4.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/T1-T8/T4.ts
+++ b/src/Theories/T1-T8/T4.ts
@@ -186,7 +186,6 @@ class t4Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 176) this.updateMilestones();

--- a/src/Theories/T1-T8/T5.ts
+++ b/src/Theories/T1-T8/T5.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import { trueFunc } from "../../Utils/functions";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
@@ -14,28 +13,28 @@ import {
 } from "../../Utils/helpers";
 
 export default async function t5(data: theoryData): Promise<simResult> {
-  let res;
+  let res: simResult;
   if(data.strat.includes("Coast")) {
-    let data2: theoryData = JSON.parse(JSON.stringify(data));
-    if(data2.strat == "T5Idle2Coast") {
-      data2.strat = "T5IdleCoast";
+    let initialData: theoryData = JSON.parse(JSON.stringify(data));
+    if(initialData.strat == "T5Idle2Coast") {
+      initialData.strat = "T5IdleCoast";
     }
-    data2.strat = data2.strat.replace("Coast", "");
-    const sim1 = new t5Sim(data2);
-    const res1 = await sim1.simulate();
-    const lastQ1 = getLastLevel("q1", res1.boughtVars);
-    const sim2 = new t5Sim(data);
-    sim2.variables[0].setOriginalCap(lastQ1);
-    sim2.variables[0].configureCap(13);
-    let last_c2 = getLastLevel("c2", res1.boughtVars);
-    sim2.variables[3].setOriginalCap(last_c2);
-    sim2.variables[3].configureCap(1);
+    initialData.strat = initialData.strat.replace("Coast", "");
+    const initialSim = new t5Sim(initialData);
+    const initialRes = await initialSim.simulate();
+    const lastQ1 = getLastLevel("q1", initialRes.boughtVars);
+    const lastC1 = getLastLevel("c1", initialRes.boughtVars) || initialSim.variables[2].level;
+    const lastC2 = getLastLevel("c2", initialRes.boughtVars);
+    const sim = new t5Sim(data);
+    sim.variables[0].setOriginalCap(lastQ1);
+    sim.variables[0].configureCap(13);
+    sim.variables[3].setOriginalCap(lastC2);
+    sim.variables[3].configureCap(1);
     if(data.strat == "T5Idle2Coast") {
-      let last_c1 = getLastLevel("c1", res1.boughtVars) || sim1.variables[2].level;
-      sim2.variables[2].setOriginalCap(last_c1);
-      sim2.variables[2].configureCap(200);
+      sim.variables[2].setOriginalCap(lastC1);
+      sim.variables[2].configureCap(200);
     }
-    res = await sim2.simulate();
+    res = await sim.simulate();
   }
   else {
     const sim = new t5Sim(data);

--- a/src/Theories/T1-T8/T5.ts
+++ b/src/Theories/T1-T8/T5.ts
@@ -152,7 +152,6 @@ class t5Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 150) this.updateMilestones();

--- a/src/Theories/T1-T8/T5.ts
+++ b/src/Theories/T1-T8/T5.ts
@@ -14,10 +14,10 @@ import {
 
 export default async function t5(data: theoryData): Promise<simResult> {
   let res: simResult;
-  if(data.strat.includes("Coast")) {
+  if(data.strat.includes("Coast") || data.strat === "T5RcvA" || data.strat === "T5RcvA2") {
     let initialData: theoryData = JSON.parse(JSON.stringify(data));
-    if(initialData.strat == "T5Idle2Coast") {
-      initialData.strat = "T5IdleCoast";
+    if(initialData.strat == "T5RcvA2") {
+      initialData.strat = "T5RcvA";
     }
     initialData.strat = initialData.strat.replace("Coast", "");
     const initialSim = new t5Sim(initialData);
@@ -30,7 +30,7 @@ export default async function t5(data: theoryData): Promise<simResult> {
     sim.variables[0].configureCap(13);
     sim.variables[3].setOriginalCap(lastC2);
     sim.variables[3].configureCap(1);
-    if(data.strat == "T5Idle2Coast") {
+    if(data.strat == "T5RcvA2") {
       sim.variables[2].setOriginalCap(lastC1);
       sim.variables[2].configureCap(200);
     }
@@ -58,21 +58,14 @@ class t5Sim extends theoryClass<theory> {
   getBuyingConditions(): conditionFunction[] {
     const conditions: Record<stratType[theory], conditionFunction[]> = {
       T5: [trueFunc, trueFunc, trueFunc, trueFunc, trueFunc],
-      T5Idle: [
-        trueFunc,
-        trueFunc,
-        () => this.maxRho + (this.lastPub - 200) / 165 < this.lastPub,
-        () => this.c2worth,
-        trueFunc
-      ],
-      T5IdleCoast: [
+      T5RcvA: [
         () => this.variables[0].shouldBuy,
         trueFunc,
         () => this.maxRho + (this.lastPub - 200) / 165 < this.lastPub,
         () => this.variables[3].shouldBuy && this.c2worth,
         trueFunc
       ],
-      T5Idle2Coast: [
+      T5RcvA2: [
         () => this.variables[0].shouldBuy,
         trueFunc,
         () => this.variables[2].shouldBuy,
@@ -161,19 +154,17 @@ class t5Sim extends theoryClass<theory> {
       if(this.variables[3].shouldFork) await this.doForkVariable(3);
     }
     this.trimBoughtVars();
-    let stratExtra = (
-        this.strat.includes("T5Idle") && !this.strat.includes("Idle2")
-    ) ? " " + logToExp(this.variables[2].cost, 1) : "";
-    if(this.strat.includes("Coast")) {
+    let stratExtra = this.strat === "T5RcvA" ? " " + logToExp(this.variables[2].cost, 1) : "";
+    if(this.strat.includes("Coast") || this.strat === "T5RcvA" || this.strat === "T5RcvA2") {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("q1", this.boughtVars))
       stratExtra += this.variables[3].prepareExtraForCap(getLastLevel("c2", this.boughtVars))
     }
-    if(this.strat.includes("Idle2")) {
-      let c1_last = getLastLevel("c1", this.boughtVars);
-      if(c1_last === 0) {
-        c1_last = this.variables[2].level;
+    if(this.strat === "T5RcvA2") {
+      let last_c1 = getLastLevel("c1", this.boughtVars);
+      if(last_c1 === 0) {
+        last_c1 = this.variables[2].level;
       }
-      stratExtra += this.variables[2].prepareExtraForCap(c1_last)
+      stratExtra += this.variables[2].prepareExtraForCap(last_c1)
     }
     return getBestResult(this.createResult(stratExtra), this.bestForkRes);
   }
@@ -197,7 +188,6 @@ class t5Sim extends theoryClass<theory> {
     }
     if(
         (id === 0 || id === 2 || id === 3) &&
-        this.strat.includes("Coast") &&
         this.variables[id].shouldBuy &&
         this.variables[id].coastingCapReached()
         // (this.variables[id].underOriginalCap() || this.maxRho >= 1000)

--- a/src/Theories/T1-T8/T5.ts
+++ b/src/Theories/T1-T8/T5.ts
@@ -80,7 +80,7 @@ class t5Sim extends theoryClass<theory> {
         () => this.variables[3].shouldBuy && this.c2worth,
         trueFunc
       ],
-      T5AI2: [
+      T5ManageQMod: [
         () => this.variables[0].cost + l10(3 + (this.variables[0].level % 10))
           <= Math.min(this.variables[1].cost, this.variables[3].cost, this.milestones[2] > 0 ? this.variables[4].cost : 1000),
         trueFunc,
@@ -88,7 +88,7 @@ class t5Sim extends theoryClass<theory> {
         () => this.c2worth,
         trueFunc,
       ],
-      T5AI2Coast: [
+      T5ManageQModCoast: [
         () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(3 + (this.variables[0].level % 10))
             <= Math.min(this.variables[1].cost, this.variables[3].cost, this.milestones[2] > 0 ? this.variables[4].cost : 1000)),
         trueFunc,

--- a/src/Theories/T1-T8/T6.ts
+++ b/src/Theories/T1-T8/T6.ts
@@ -389,7 +389,6 @@ class t6Sim extends theoryClass<theory> {
 
     async simulate(): Promise<simResult> {
         while (!this.endSimulation()) {
-            if (!global.simulating) break;
             this.tick();
             this.updateSimStatus();
             if (this.lastPub < 150) this.updateMilestones();

--- a/src/Theories/T1-T8/T6.ts
+++ b/src/Theories/T1-T8/T6.ts
@@ -25,7 +25,7 @@ export default async function t6(data: theoryData): Promise<simResult> {
         const lastR1 = getLastLevel("r1", res1.boughtVars);
         const sim2 = new t6Sim(data);
         sim2.variables[0].setOriginalCap(lastQ1);
-        if (data.strat.includes("T6C5d") || data2.strat.includes("IdleRecovery") || data2.strat.includes("T6AI")) {
+        if (data.strat.includes("T6C5d") || data2.strat.includes("RcvI") || data2.strat.includes("T6NoC34Mod")) {
             sim2.variables[0].configureCap(4);
         } else {
             // This is the observed max for best idle strat.
@@ -51,7 +51,7 @@ class t6Sim extends theoryClass<theory> {
     stopC12: [number, number, boolean];
 
     getBuyingConditions(): conditionFunction[] {
-        const t6SnaxIdleRecoveryMaker = (start_point: number = 0): (boolean | conditionFunction)[] => {
+        const T6C125dStopC12RcvImaker = (start_point: number = 0): (boolean | conditionFunction)[] => {
             return [
                 () => {
                     if (this.lastPub - start_point >= this.maxRho) return true;
@@ -72,7 +72,7 @@ class t6Sim extends theoryClass<theory> {
                 true,
             ]
         }
-        const t6SnaxIdleRecoveryCoastMaker = (start_point: number = 0): (boolean | conditionFunction)[] => {
+        const T6C125dStopC12RcvICoastMaker = (start_point: number = 0): (boolean | conditionFunction)[] => {
             return [
                 () => {
                     if (!this.variables[0].shouldBuy) return false;
@@ -113,8 +113,8 @@ class t6Sim extends theoryClass<theory> {
                 false,
                 true
             ],
-            T6Snax: [true, true, true, true, () => this.stopC12[2], () => this.stopC12[2], false, false, true],
-            T6SnaxCoast: [
+            T6C125StopC12: [true, true, true, true, () => this.stopC12[2], () => this.stopC12[2], false, false, true],
+            T6C125StopC12Coast: [
                 () => this.variables[0].shouldBuy,
                 true,
                 () => this.variables[2].shouldBuy,
@@ -125,18 +125,18 @@ class t6Sim extends theoryClass<theory> {
                 false,
                 true
             ],
-            T6SnaxIdleRecovery: t6SnaxIdleRecoveryMaker(0),
-            T6SnaxIdleRecoveryCoast: t6SnaxIdleRecoveryCoastMaker(0),
-            T6SnaxIdleRecoveryM1: t6SnaxIdleRecoveryMaker(1),
-            T6SnaxIdleRecoveryM1Coast: t6SnaxIdleRecoveryCoastMaker(1),
-            T6SnaxIdleRecoveryM2: t6SnaxIdleRecoveryMaker(2),
-            T6SnaxIdleRecoveryM2Coast: t6SnaxIdleRecoveryCoastMaker(2),
-            T6SnaxIdleRecoveryM3: t6SnaxIdleRecoveryMaker(3),
-            T6SnaxIdleRecoveryM3Coast: t6SnaxIdleRecoveryCoastMaker(3),
-            T6SnaxIdleRecoveryM4: t6SnaxIdleRecoveryMaker(4),
-            T6SnaxIdleRecoveryM4Coast: t6SnaxIdleRecoveryCoastMaker(4),
-            T6SnaxIdleRecoveryM5: t6SnaxIdleRecoveryMaker(5),
-            T6SnaxIdleRecoveryM5Coast: t6SnaxIdleRecoveryCoastMaker(5),
+            T6C125dStopC12RcvI: T6C125dStopC12RcvImaker(0),
+            T6C125dStopC12RcvICoast: T6C125dStopC12RcvICoastMaker(0),
+            T6C125dStopC12RcvI1: T6C125dStopC12RcvImaker(1),
+            T6C125dStopC12RcvI1Coast: T6C125dStopC12RcvICoastMaker(1),
+            T6C125dStopC12RcvI2: T6C125dStopC12RcvImaker(2),
+            T6C125dStopC12RcvI2Coast: T6C125dStopC12RcvICoastMaker(2),
+            T6C125dStopC12RcvI3: T6C125dStopC12RcvImaker(3),
+            T6C125dStopC12RcvI3Coast: T6C125dStopC12RcvICoastMaker(3),
+            T6C125dStopC12RcvI4: T6C125dStopC12RcvImaker(4),
+            T6C125dStopC12RcvI4Coast: T6C125dStopC12RcvICoastMaker(4),
+            T6C125dStopC12RcvI5: T6C125dStopC12RcvImaker(5),
+            T6C125dStopC12RcvI5Coast: T6C125dStopC12RcvICoastMaker(5),
             T6C3d: [
                 () => this.variables[0].cost + l10(3) < Math.min(this.variables[1].cost, this.milestones[0] > 0 ? this.variables[3].cost : Infinity, this.variables[6].cost),
                 true,
@@ -210,7 +210,7 @@ class t6Sim extends theoryClass<theory> {
                 false,
                 true,
             ],
-            T6C5dIdleRecovery: [
+            T6C5dRcvI: [
                 () => {
                     if (this.lastPub >= this.maxRho) return true;
                     return this.variables[0].cost + l10(7 + (this.variables[0].level % 10))
@@ -229,7 +229,7 @@ class t6Sim extends theoryClass<theory> {
                 false,
                 true,
             ],
-            T6C5dIdleRecoveryCoast: [
+            T6C5dRcvICoast: [
                 () => {
                     if (!this.variables[0].shouldBuy) return false;
                     if (this.lastPub >= this.maxRho) return true;
@@ -250,8 +250,8 @@ class t6Sim extends theoryClass<theory> {
                 false,
                 true,
             ],
-            T6AI: [],
-            T6AICoast: [],
+            T6NoC34Mod: [],
+            T6NoC34ModCoast: [],
         };
         return toCallables(conditions[this.strat]);
     }
@@ -288,33 +288,33 @@ class t6Sim extends theoryClass<theory> {
                 return [0, 2];
             case "T6C5Coast":
                 return [0, 2];
-            case "T6Snax":
+            case "T6C125StopC12":
                 return [0, 3, 2];
-            case "T6SnaxCoast":
+            case "T6C125StopC12Coast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecovery":
+            case "T6C125dStopC12RcvI":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryCoast":
+            case "T6C125dStopC12RcvICoast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM1":
+            case "T6C125dStopC12RcvI1":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM1Coast":
+            case "T6C125dStopC12RcvI1Coast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM2":
+            case "T6C125dStopC12RcvI2":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM2Coast":
+            case "T6C125dStopC12RcvI2Coast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM3":
+            case "T6C125dStopC12RcvI3":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM3Coast":
+            case "T6C125dStopC12RcvI3Coast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM4":
+            case "T6C125dStopC12RcvI4":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM4Coast":
+            case "T6C125dStopC12RcvI4Coast":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM5":
+            case "T6C125dStopC12RcvI5":
                 return [0, 3, 2];
-            case "T6SnaxIdleRecoveryM5Coast":
+            case "T6C125dStopC12RcvI5Coast":
                 return [0, 3, 2];
             case "T6C3d":
                 return [0];
@@ -328,13 +328,13 @@ class t6Sim extends theoryClass<theory> {
                 return [0, 2];
             case "T6C5dCoast":
                 return [0, 2];
-            case "T6AI":
+            case "T6NoC34Mod":
                 return [0, 3, 2];
-            case "T6AICoast":
+            case "T6NoC34ModCoast":
                 return [0, 3, 2];
-            case "T6C5dIdleRecovery":
+            case "T6C5dRcvI":
                 return [0, 2];
-            case "T6C5dIdleRecoveryCoast":
+            case "T6C5dRcvICoast":
                 return [0, 2];
         }
     }
@@ -399,7 +399,7 @@ class t6Sim extends theoryClass<theory> {
             if (this.variables[2].shouldFork) await this.doForkVariable(2);
         }
         this.trimBoughtVars();
-        let stratExtra = this.strat.includes("T6Snax") ? " " + logToExp(this.stopC12[0], 1) : "";
+        let stratExtra = this.strat.includes("T6C125StopC12") ? " " + logToExp(this.stopC12[0], 1) : "";
         if (this.strat.includes("Coast")) {
             stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("q1", this.boughtVars)) +
                 this.variables[2].prepareExtraForCap(getLastLevel("r1", this.boughtVars));
@@ -450,7 +450,7 @@ class t6Sim extends theoryClass<theory> {
     }
 
     buyVariables() {
-        if (this.strat !== "T6AI" && this.strat != "T6AICoast") super.buyVariables();
+        if (this.strat !== "T6NoC34Mod" && this.strat != "T6NoC34ModCoast") super.buyVariables();
         else super.buyVariablesWeight();
     }
 

--- a/src/Theories/T1-T8/T6.ts
+++ b/src/Theories/T1-T8/T6.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/T1-T8/T7.ts
+++ b/src/Theories/T1-T8/T7.ts
@@ -4,20 +4,20 @@ import Currency from "../../Utils/currency";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost } from '../../Utils/cost';
-import { add_old, l10, getR9multiplier, toCallables, getLastLevel, getBestResult } from "../../Utils/helpers";
+import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult } from "../../Utils/helpers";
 
 export default async function t7(data: theoryData): Promise<simResult> {
   let res;
   if(data.strat.includes("Coast")) {
-    let data2: theoryData = JSON.parse(JSON.stringify(data));
-    data2.strat = data2.strat.replace("Coast", "");
-    const sim1 = new t7Sim(data2);
-    const res1 = await sim1.simulate();
-    const lastQ1 = getLastLevel("q1", res1.boughtVars);
-    const sim2 = new t7Sim(data);
-    sim2.variables[0].setOriginalCap(lastQ1);
-    sim2.variables[0].configureCap(13)
-    res = await sim2.simulate();
+    let initialData: theoryData = JSON.parse(JSON.stringify(data));
+    initialData.strat = initialData.strat.replace("Coast", "");
+    const initialSim = new t7Sim(initialData);
+    const initialRes = await initialSim.simulate();
+    const lastQ1 = getLastLevel("q1", initialRes.boughtVars);
+    const sim = new t7Sim(data);
+    sim.variables[0].setOriginalCap(lastQ1);
+    sim.variables[0].configureCap(13);
+    res = await sim.simulate();
   }
   else {
     const sim = new t7Sim(data);
@@ -28,8 +28,6 @@ export default async function t7(data: theoryData): Promise<simResult> {
 }
 
 type theory = "T7";
-
-const add = add_old;
 
 class t7Sim extends theoryClass<theory> {
   rho2: Currency;
@@ -56,7 +54,25 @@ class t7Sim extends theoryClass<theory> {
       T7C12dCoast: [() => q1CoastCond() && (this.variables[0].cost + 1 < this.variables[2].cost), () => this.variables[1].cost + l10(8) < this.variables[2].cost, true, false, false, false, false],
       T7C3d: [() => this.variables[0].cost + 1 < this.variables[3].cost, false, false, true, false, false, false],
       T7C3dCoast: [() => q1CoastCond() && (this.variables[0].cost + 1 < this.variables[3].cost), false, false, true, false, false, false],
-      T7PlaySpqcey: [
+      T7NoC12d: [
+        () => this.variables[0].cost + l10(4) < this.variables[6].cost,
+        () => false,
+        () => false,
+        () => this.variables[3].cost + 1 < this.variables[6].cost,
+        () => this.variables[4].cost + 1 < this.variables[6].cost,
+        () => this.variables[5].cost + l10(4) < this.variables[6].cost,
+        true,
+      ],
+      T7NoC12dCoast: [
+        () => q1CoastCond() && (this.variables[0].cost + l10(4) < this.variables[6].cost),
+        () => false,
+        () => false,
+        () => this.variables[3].cost + 1 < this.variables[6].cost,
+        () => this.variables[4].cost + 1 < this.variables[6].cost,
+        () => this.variables[5].cost + l10(4) < this.variables[6].cost,
+        true,
+      ],
+      T7Ratio: [
         () => this.variables[0].cost + l10(4) < this.variables[6].cost,
         () => this.variables[1].cost + l10(10 + this.variables[2].level) < this.variables[2].cost,
         () => this.variables[2].cost + l10(this.c2ratio) < this.variables[6].cost,
@@ -65,7 +81,7 @@ class t7Sim extends theoryClass<theory> {
         () => this.variables[5].cost + l10(4) < this.variables[6].cost,
         true,
       ],
-      T7PlaySpqceyCoast: [
+      T7RatioCoast: [
         () => q1CoastCond() && (this.variables[0].cost + l10(4) < this.variables[6].cost),
         () => this.variables[1].cost + l10(10 + this.variables[2].level) < this.variables[2].cost,
         () => this.variables[2].cost + l10(this.c2ratio) < this.variables[6].cost,
@@ -90,7 +106,6 @@ class t7Sim extends theoryClass<theory> {
   }
   getMilestonePriority(): number[] {
     switch (this.strat) {
-      case "T7": case "T7Coast": return [1, 0, 2, 3, 4];
       case "T7C12": case "T7C12Coast": return [4];
       case "T7C3": case "T7C3Coast": return [1];
       case "T7noC12": case "T7noC12Coast": return [1, 0, 2, 3];
@@ -98,7 +113,7 @@ class t7Sim extends theoryClass<theory> {
       case "T7C56": case "T7C56Coast": return [0, 2, 3];
       case "T7C12d": case "T7C12dCoast": return [4];
       case "T7C3d": case "T7C3dCoast": return [1];
-      case "T7PlaySpqcey": case "T7PlaySpqceyCoast": return [1, 0, 2, 3, 4];
+      default: return [1, 0, 2, 3, 4];
     }
   }
   getTotMult(val: number): number {
@@ -122,11 +137,12 @@ class t7Sim extends theoryClass<theory> {
     ];
     this.drho13 = 0;
     this.drho23 = 0;
+    this.c2ratio = 100;
     if (this.lastPub >= 100) this.c2ratio = 100;
     if (this.lastPub >= 175) this.c2ratio = 10;
     if (this.lastPub >= 250) this.c2ratio = 20;
     if (this.lastPub >= 275) this.c2ratio = 50;
-    if (this.lastPub >= 300) this.c2ratio = Infinity;
+    if (this.lastPub >= 300) this.c2ratio = 100;
     this.updateMilestones();
   }
   async simulate(): Promise<simResult> {
@@ -139,7 +155,7 @@ class t7Sim extends theoryClass<theory> {
       if(this.variables[0].shouldFork) await this.doForkVariable(0);
     }
     this.trimBoughtVars();
-    let stratExtra = this.strat.includes("T7PlaySpqcey") && this.c2ratio !== Infinity ? this.c2ratio.toString() : "";
+    let stratExtra = this.strat.includes("T7Ratio") ? this.c2ratio.toString() : "";
     if(this.strat.includes("Coast")) {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("q1", this.boughtVars));
     }

--- a/src/Theories/T1-T8/T7.ts
+++ b/src/Theories/T1-T8/T7.ts
@@ -48,10 +48,10 @@ class t7Sim extends theoryClass<theory> {
       T7C3Coast: [q1CoastCond, false, false, true, false, false, false],
       T7noC12: [true, false, false, true, true, true, true],
       T7noC12Coast: [q1CoastCond, false, false, true, true, true, true],
-      T7noC123: [true, false, false, false, true, true, true],
-      T7noC123Coast: [q1CoastCond, false, false, false, true, true, true],
-      T7noC1234: [true, false, false, false, false, true, true],
-      T7noC1234Coast: [q1CoastCond, false, false, false, false, true, true],
+      T7C456: [true, false, false, false, true, true, true],
+      T7C456Coast: [q1CoastCond, false, false, false, true, true, true],
+      T7C56: [true, false, false, false, false, true, true],
+      T7C56Coast: [q1CoastCond, false, false, false, false, true, true],
       T7C12d: [() => this.variables[0].cost + 1 < this.variables[2].cost, () => this.variables[1].cost + l10(8) < this.variables[2].cost, true, false, false, false, false],
       T7C12dCoast: [() => q1CoastCond() && (this.variables[0].cost + 1 < this.variables[2].cost), () => this.variables[1].cost + l10(8) < this.variables[2].cost, true, false, false, false, false],
       T7C3d: [() => this.variables[0].cost + 1 < this.variables[3].cost, false, false, true, false, false, false],
@@ -94,8 +94,8 @@ class t7Sim extends theoryClass<theory> {
       case "T7C12": case "T7C12Coast": return [4];
       case "T7C3": case "T7C3Coast": return [1];
       case "T7noC12": case "T7noC12Coast": return [1, 0, 2, 3];
-      case "T7noC123": case "T7noC123Coast": return [0, 2, 3];
-      case "T7noC1234": case "T7noC1234Coast": return [0, 2, 3];
+      case "T7C456": case "T7C456Coast": return [0, 2, 3];
+      case "T7C56": case "T7C56Coast": return [0, 2, 3];
       case "T7C12d": case "T7C12dCoast": return [4];
       case "T7C3d": case "T7C3dCoast": return [1];
       case "T7PlaySpqcey": case "T7PlaySpqceyCoast": return [1, 0, 2, 3, 4];

--- a/src/Theories/T1-T8/T7.ts
+++ b/src/Theories/T1-T8/T7.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Currency from "../../Utils/currency";
 import Variable from "../../Utils/variable";

--- a/src/Theories/T1-T8/T7.ts
+++ b/src/Theories/T1-T8/T7.ts
@@ -147,7 +147,6 @@ class t7Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 175) this.updateMilestones();

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -189,7 +189,6 @@ class t8Sim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       if (this.lastPub < 220) this.updateMilestones();

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -51,7 +51,7 @@ class t8Sim extends theoryClass<theory> {
       T8noC3: [true, true, false, true, true],
       T8noC5: [true, true, true, true, false],
       T8noC35: [true, true, false, true, false],
-      T8Snax: [() => this.curMult < 1.6, true, () => this.curMult < 2.3, true, () => this.curMult < 2.3],
+      T8MC: [() => this.curMult < 1.6, true, () => this.curMult < 2.3, true, () => this.curMult < 2.3],
       T8Coast: [
         () => this.variables[0].shouldBuy,
         true,
@@ -77,14 +77,14 @@ class t8Sim extends theoryClass<theory> {
         true,
         () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
       ],
-      T8PlaySolarswap: [
+      T8PlaySolarReset: [
         () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
       ],
-      T8PlaySolarswapCoast: [
+      T8PlaySolarResetCoast: [
         () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
         true,
         () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -62,29 +62,29 @@ class t8Sim extends theoryClass<theory> {
       T8noC5d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, false],
       T8noC35d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, false],
       T8d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, true],
-      T8Play: [
-        () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      T8Mod: [
+        () => this.variables[0].cost + l10(5 + 0.5 * (this.variables[0].level % 10)) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[4].cost + l10(4) < Math.min(this.variables[1].cost, this.variables[3].cost),
       ],
-      T8PlayCoast: [
-        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      T8ModCoast: [
+        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(5 + 0.5 * (this.variables[0].level % 10)) < Math.min(this.variables[1].cost, this.variables[3].cost)),
         true,
         () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
         true,
-        () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+        () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(4) < Math.min(this.variables[1].cost, this.variables[3].cost)),
       ],
-      T8PlaySolarReset: [
-        () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      T8ModReset: [
+        () => this.variables[0].cost + l10(5 + 0.5 * (this.variables[0].level % 10)) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
         true,
         () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
       ],
-      T8PlaySolarResetCoast: [
-        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      T8ModResetCoast: [
+        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(5 + 0.5 * (this.variables[0].level % 10)) < Math.min(this.variables[1].cost, this.variables[3].cost)),
         true,
         () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
         true,
@@ -236,7 +236,7 @@ class t8Sim extends theoryClass<theory> {
     this.dn();
 
     this.msTimer++;
-    if (this.msTimer === 335 && this.strat.includes("Solarswap")) {
+    if (this.msTimer === 335 && this.strat.includes("Reset")) {
       this.x = this.defaultStates[this.milestones[0]][0];
       this.y = this.defaultStates[this.milestones[0]][1];
       this.z = this.defaultStates[this.milestones[0]][2];

--- a/src/Theories/Unofficial-CTs/BT.ts
+++ b/src/Theories/Unofficial-CTs/BT.ts
@@ -54,7 +54,6 @@ class btSim extends theoryClass<theory> {
   }
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestones();

--- a/src/Theories/Unofficial-CTs/BT.ts
+++ b/src/Theories/Unofficial-CTs/BT.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/Unofficial-CTs/TC.ts
+++ b/src/Theories/Unofficial-CTs/TC.ts
@@ -1,4 +1,3 @@
-import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, LinearValue, StepwisePowerSumValue } from "../../Utils/value";

--- a/src/Theories/Unofficial-CTs/TC.ts
+++ b/src/Theories/Unofficial-CTs/TC.ts
@@ -215,7 +215,6 @@ class tcSim extends theoryClass<theory> {
 
   async simulate(): Promise<simResult> {
     while (!this.endSimulation()) {
-      if (!global.simulating) break;
       this.tick();
       this.updateSimStatus();
       this.updateMilestones();

--- a/src/Theories/theory.ts
+++ b/src/Theories/theory.ts
@@ -2,13 +2,11 @@ import Currency from "../Utils/currency";
 import Variable from "../Utils/variable";
 import {
   binaryInsertionSearch,
-  convertTime,
   defaultResult,
-  formatNumber,
   getBestResult,
-  logToExp
 } from "../Utils/helpers";
 import jsonData from "../Data/data.json";
+import { global } from "../Sim/main";
 
 /** Base class for a theory */
 export default abstract class theoryClass<theory extends theoryType> {
@@ -289,6 +287,7 @@ export default abstract class theoryClass<theory extends theoryType> {
    * @returns true if it will break out of the simulation loop
    */
   endSimulation(): boolean {
+    if (!global.simulating) return true;
     return this.evaluateForcedPubConditions() && (this.evaluatePubConditions() || (this.doSimEndConditions() && this.evaluateSimEndConditions()));
   }
 

--- a/src/Theories/theory.ts
+++ b/src/Theories/theory.ts
@@ -230,9 +230,9 @@ export default abstract class theoryClass<theory extends theoryType> {
   /**
    * Updates milestones
    */
-  updateMilestones(): void {
+  updateMilestones(priority?: number[]): void {
     const rho = Math.max(this.maxRho, this.lastPub);
-    const priority = this.getMilestonePriority();
+    priority = priority ?? this.getMilestonePriority();
     let milestoneCount = this.milestoneUnlockSteps > 0 
       ? Math.floor(rho / this.milestoneUnlockSteps)
       : binaryInsertionSearch(this.milestoneUnlocks, rho);

--- a/src/Utils/helpers.ts
+++ b/src/Utils/helpers.ts
@@ -265,3 +265,20 @@ export function reverseMulti(theory: string, value: number, sigma: number) {
 export function isMainTheory(theory: string): boolean {
   return /T[1-8]/.test(theory);
 }
+
+export function newtonMax(
+  x: number,
+  f: (x: number) => number,
+  h = 1e-5
+): number {
+  const df = (t: number) => (f(t + h) - f(t - h)) / (2 * h);
+  const ddf = (t: number) => (f(t + h) - 2 * f(t) + f(t - h)) / (h * h);
+
+  while (Math.abs(df(x)) > h) {
+    const second = ddf(x);
+    if (second === 0) break;
+    x = x - df(x) / second;
+  }
+
+  return x;
+}

--- a/src/Utils/variable.ts
+++ b/src/Utils/variable.ts
@@ -107,7 +107,7 @@ export default class Variable {
     return ` ${this.name}: ${actualLast}` // ${this.name}delta: ${this.originalCap - actualLast}`
   }
   /**
-   * If the coasting cap is reaches
+   * If the coasting cap is reached
    * @returns true if the coasting cap is reached
    */
   coastingCapReached() {


### PR DESCRIPTION
Renamed theory strategies as a global effort with the guide team to make strat naming more consistent and to remove reference to player names in the strat names