### PR TITLE
T8 Low Milestone Strategy Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3382,10 +3382,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -407,31 +407,43 @@
       "tauFactor": 1,
       "strats": {
         "T8": {
-          "stratFilterCondition": "Idle || (Semi-Idle && rho < 100)"
+          "stratFilterCondition": "Idle && (rho < 52 || rho >= 160)"
         },
-        "T8SingleMS": {
-          "stratFilterCondition": "Semi-Idle && rho >= 20 && rho < 80"
+        "T8M1": {
+          "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 80 && rho < 160"
+        },
+        "T8M3": {
+          "stratFilterCondition": "Idle && rho >= 52 && rho < 80"
+        },
+        "T8Coast": {
+          "stratFilterCondition": "Semi-Idle && ((rho >= 20 && rho < 52) || rho >= 220)"
+        },
+        "T8M1Coast": {
+          "stratFilterCondition": "Semi-Idle && rho >= 80 && rho < 160"
+        },
+        "T8M3Coast": {
+          "stratFilterCondition": "Semi-Idle && rho >= 52 && rho < 80"
         },
         "T8noC3": {
-          "stratFilterCondition": "(Idle || Semi-Idle) && ((rho < 40) || (rho >=50 && rho < 80) || (rho >= 155 && rho < 160))"
+          "stratFilterCondition": "Idle && ((rho < 40) || (rho >=50 && rho < 80) || (rho >= 160 && rho < 220))"
+        },
+        "T8noC3Coast": {
+          "stratFilterCondition": "Semi-Idle && ((rho < 40) || (rho >=50 && rho < 80))"
         },
         "T8noC5": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 160 && rho < 220"
         },
+        "T8noC5Coast": {
+          "stratFilterCondition": "Semi-Idle && rho >= 160 && rho < 220"
+        },
         "T8noC35": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 80 && rho < 160"
         },
+        "T8noC35Coast": {
+          "stratFilterCondition": "Semi-Idle && rho >= 80 && rho < 160"
+        },
         "T8Snax": {
-          "stratFilterCondition": "Semi-Idle"
-        },
-        "T8SnaxSingleMS": {
-          "stratFilterCondition": "Semi-Idle && rho >= 50 && rho < 60"
-        },
-        "T8Coast": {
-          "stratFilterCondition": "Semi-Idle"
-        },
-        "T8SingleMSCoast": {
-          "stratFilterCondition": "Semi-Idle && rho >= 20 && rho < 80"
+          "stratFilterCondition": "Semi-Idle && (rho < 160 || rho >= 220)"
         },
         "T8noC3d": {
           "stratFilterCondition": "(Active || Very-Active) && ((rho < 40) || (rho >= 50 && rho < 80) || (rho >= 160 && rho < 220))"
@@ -440,10 +452,10 @@
           "stratFilterCondition": "(Active || Very-Active) && ((rho < 40) || (rho >= 50 && rho < 80) || (rho >= 160 && rho < 220))"
         },
         "T8noC3dSingleMS": {
-          "stratFilterCondition": "(Active || Very-Active) && ((rho >= 20 && rho < 40) || (rho >= 50 && rho < 80))"
+          "stratFilterCondition": "(Active || Very-Active) && (rho >= 50 && rho < 76)"
         },
         "T8noC3dSingleMSCoast": {
-          "stratFilterCondition": "(Active || Very-Active) && ((rho >= 20 && rho < 40) || (rho >= 50 && rho < 80))"
+          "stratFilterCondition": "(Active || Very-Active) && (rho >= 50 && rho < 76)"
         },
         "T8noC5d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 160 && rho < 220"
@@ -454,23 +466,20 @@
         "T8noC35d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 72 && rho < 160"
         },
-        "T8Play": {
-          "stratFilterCondition": "Active && ((rho >= 20 && rho < 100) || (rho >= 220))"
+        "T8noC35dCoast": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 72 && rho < 160"
         },
-        "T8PlaySingleMS": {
-          "stratFilterCondition": "Active && rho >= 160 && rho <= 220"
+        "T8Play": {
+          "stratFilterCondition": "false"
         },
         "T8PlayCoast": {
-          "stratFilterCondition": "Active && ((rho >= 20 && rho < 100) || (rho >= 220))"
-        },
-        "T8PlaySingleMSCoast": {
-          "stratFilterCondition": "Active && rho >= 160 && rho <= 220"
+          "stratFilterCondition": "Active && ((rho >= 20 && rho < 52) || (rho >= 220))"
         },
         "T8PlaySolarswap": {
-          "stratFilterCondition": "Very-Active && rho >= 40"
+          "stratFilterCondition": "Very-Active && ((rho >= 40 && rho < 52) || (rho >= 155))"
         },
         "T8PlaySolarswapCoast": {
-          "stratFilterCondition": "Very-Active && rho >= 40"
+          "stratFilterCondition": "Very-Active && ((rho >= 40 && rho < 52) || (rho >= 155))"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -409,6 +409,9 @@
         "T8": {
           "stratFilterCondition": "Idle || (Semi-Idle && rho < 100)"
         },
+        "T8SingleMS": {
+          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+        },
         "T8noC3": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho < 25"
         },
@@ -421,11 +424,23 @@
         "T8Snax": {
           "stratFilterCondition": "Semi-Idle"
         },
+        "T8SnaxSingleMS": {
+          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+        },
         "T8Coast": {
           "stratFilterCondition": "Semi-Idle"
         },
+        "T8SingleMSCoast": {
+          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+        },
         "T8noC3d": {
           "stratFilterCondition": "(Active || Very-Active) && rho < 60"
+        },
+        "T8noC3d2": {
+          "stratFilterCondition": "(Active || Very-Active) && rho < 60"
+        },
+        "T8noC3dSingleMS": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 40 && rho < 60"
         },
         "T8noC5d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 160 && rho < 220"
@@ -436,17 +451,20 @@
         "T8d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 40 && rho < 100"
         },
+        "T8dSingleMS": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 37 && rho < 60"
+        },
         "T8Play": {
-          "stratFilterCondition": "Active && rho >= 220"
+          "stratFilterCondition": "Active && ((rho < 5) || (rho >= 20 && rho < 60) || (rho >= 80 && rho < 100) || rho >= 220)"
         },
         "T8PlayCoast": {
-          "stratFilterCondition": "Active && rho >= 220"
+          "stratFilterCondition": "Active && ((rho < 5) || (rho >= 20 && rho < 60) || (rho >= 80 && rho < 100) || rho >= 220)"
         },
         "T8PlaySolarswap": {
-          "stratFilterCondition": "Very-Active"
+          "stratFilterCondition": "Very-Active && rho > 60"
         },
         "T8PlaySolarswapCoast": {
-          "stratFilterCondition": "Very-Active"
+          "stratFilterCondition": "Very-Active && rho > 60"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -410,61 +410,67 @@
           "stratFilterCondition": "Idle || (Semi-Idle && rho < 100)"
         },
         "T8SingleMS": {
-          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+          "stratFilterCondition": "Semi-Idle && rho >= 20 && rho < 80"
         },
         "T8noC3": {
-          "stratFilterCondition": "(Idle || Semi-Idle) && rho < 25"
+          "stratFilterCondition": "(Idle || Semi-Idle) && ((rho < 40) || (rho >=50 && rho < 80) || (rho >= 155 && rho < 160))"
         },
         "T8noC5": {
           "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 160 && rho < 220"
         },
         "T8noC35": {
-          "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 100 && rho < 160"
+          "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 80 && rho < 160"
         },
         "T8Snax": {
           "stratFilterCondition": "Semi-Idle"
         },
         "T8SnaxSingleMS": {
-          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+          "stratFilterCondition": "Semi-Idle && rho >= 50 && rho < 60"
         },
         "T8Coast": {
           "stratFilterCondition": "Semi-Idle"
         },
         "T8SingleMSCoast": {
-          "stratFilterCondition": "Semi-Idle && rho >= 37 && rho < 60"
+          "stratFilterCondition": "Semi-Idle && rho >= 20 && rho < 80"
         },
         "T8noC3d": {
-          "stratFilterCondition": "(Active || Very-Active) && rho < 60"
+          "stratFilterCondition": "(Active || Very-Active) && ((rho < 40) || (rho >= 50 && rho < 80) || (rho >= 160 && rho < 220))"
         },
-        "T8noC3d2": {
-          "stratFilterCondition": "(Active || Very-Active) && rho < 60"
+        "T8noC3dCoast": {
+          "stratFilterCondition": "(Active || Very-Active) && ((rho < 40) || (rho >= 50 && rho < 80) || (rho >= 160 && rho < 220))"
         },
         "T8noC3dSingleMS": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 40 && rho < 60"
+          "stratFilterCondition": "(Active || Very-Active) && ((rho >= 20 && rho < 40) || (rho >= 50 && rho < 80))"
+        },
+        "T8noC3dSingleMSCoast": {
+          "stratFilterCondition": "(Active || Very-Active) && ((rho >= 20 && rho < 40) || (rho >= 50 && rho < 80))"
         },
         "T8noC5d": {
           "stratFilterCondition": "(Active || Very-Active) && rho >= 160 && rho < 220"
         },
+        "T8noC5dCoast": {
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 160 && rho < 220"
+        },
         "T8noC35d": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 100 && rho < 160"
-        },
-        "T8d": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 40 && rho < 100"
-        },
-        "T8dSingleMS": {
-          "stratFilterCondition": "(Active || Very-Active) && rho >= 37 && rho < 60"
+          "stratFilterCondition": "(Active || Very-Active) && rho >= 72 && rho < 160"
         },
         "T8Play": {
-          "stratFilterCondition": "Active && ((rho < 5) || (rho >= 20 && rho < 60) || (rho >= 80 && rho < 100) || rho >= 220)"
+          "stratFilterCondition": "Active && ((rho >= 20 && rho < 100) || (rho >= 220))"
+        },
+        "T8PlaySingleMS": {
+          "stratFilterCondition": "Active && rho >= 160 && rho <= 220"
         },
         "T8PlayCoast": {
-          "stratFilterCondition": "Active && ((rho < 5) || (rho >= 20 && rho < 60) || (rho >= 80 && rho < 100) || rho >= 220)"
+          "stratFilterCondition": "Active && ((rho >= 20 && rho < 100) || (rho >= 220))"
+        },
+        "T8PlaySingleMSCoast": {
+          "stratFilterCondition": "Active && rho >= 160 && rho <= 220"
         },
         "T8PlaySolarswap": {
-          "stratFilterCondition": "Very-Active && rho > 60"
+          "stratFilterCondition": "Very-Active && rho >= 40"
         },
         "T8PlaySolarswapCoast": {
-          "stratFilterCondition": "Very-Active && rho > 60"
+          "stratFilterCondition": "Very-Active && rho >= 40"
         }
       }
     },

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -409,20 +409,8 @@
         "T8": {
           "stratFilterCondition": "Idle && (rho < 52 || rho >= 160)"
         },
-        "T8M1": {
-          "stratFilterCondition": "(Idle || Semi-Idle) && rho >= 80 && rho < 160"
-        },
-        "T8M3": {
-          "stratFilterCondition": "Idle && rho >= 52 && rho < 80"
-        },
         "T8Coast": {
           "stratFilterCondition": "Semi-Idle && ((rho >= 20 && rho < 52) || rho >= 220)"
-        },
-        "T8M1Coast": {
-          "stratFilterCondition": "Semi-Idle && rho >= 80 && rho < 160"
-        },
-        "T8M3Coast": {
-          "stratFilterCondition": "Semi-Idle && rho >= 52 && rho < 80"
         },
         "T8noC3": {
           "stratFilterCondition": "Idle && ((rho < 40) || (rho >=50 && rho < 80) || (rho >= 160 && rho < 220))"

--- a/src/Theories/CTs/RZ.ts
+++ b/src/Theories/CTs/RZ.ts
@@ -238,7 +238,7 @@ export default async function rz(data: theoryData) {
             retArr.push(ret);
         }
         let bestRet = retArr[0];
-        for(let i = 0; i < retArr.length; i++) {
+        for(let i = 1; i < retArr.length; i++) {
             bestRet = getBestResult(bestRet, retArr[i]);
         }
         return bestRet;
@@ -605,12 +605,11 @@ class rzSim extends theoryClass<theory> {
             else throw error;
         }
         let stratExtra = "";
-        if (this.strat.includes("BH"))
-        {
+        if (this.strat.includes("BH")) {
             stratExtra += ` t=${this.bhAtRecovery ? this.t_var.toFixed(2) : this.targetZero.toFixed(2)}`
         }
         if (this.strat.includes("MS") && this.swapPointDelta != 0) {
-            stratExtra += ` swap:${logToExp(this.lastPub + this.swapPointDelta, 2)}`
+            stratExtra += ` ${logToExp(this.lastPub + this.swapPointDelta, 2)}`
         }
         if (this.normalPubRho != -1) {
             // if(this.maxC1LevelActual == -1)
@@ -618,7 +617,7 @@ class rzSim extends theoryClass<theory> {
             // else
             //     stratExtra += ` c1=${this.variables[0].level}/${this.maxC1LevelActual} c2=${this.variables[1].level}`
         }
-        if (this.maxW1 !== Infinity){
+        if (this.maxW1 !== Infinity) {
             stratExtra += ` w1: ${this.maxW1}`;
         }
         this.trimBoughtVars();

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -3,32 +3,88 @@ import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost } from '../../Utils/cost';
-import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult } from "../../Utils/helpers";
+import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult, logToExp } from "../../Utils/helpers";
+
+const MXStrats = ["T8", "T8Coast", "T8Snax", "T8d", "T8noC3d"];
+const isMX = (strat: string, rho: number) => (
+  rho >= 37
+  && rho < 60
+  && (
+    strat.includes("SingleMS")
+    || MXStrats.includes(strat)
+  )
+);
 
 export default async function t8(data: theoryData): Promise<simResult> {
-  let res;
-  if(!data.strat.includes("Coast")) {
-    const sim = new t8Sim(data);
-    res = await sim.simulate();
+  async function getResult (data: theoryData, MX: number = 0, ss: number = 0): Promise<simResult> {
+    let res;
+    if (!data.strat.includes("Coast")) {
+      const sim = new t8Sim(data);
+      sim.milestoneVariant = MX;
+      sim.ssPoint = ss;
+      res = await sim.simulate();
+    }
+    else {
+      let data2: theoryData = JSON.parse(JSON.stringify(data));
+      data2.strat = data2.strat.replace("Coast", "");
+      const sim1 = new t8Sim(data2);
+      sim1.milestoneVariant = MX;
+      sim1.ssPoint = ss;
+      const res1 = await sim1.simulate();
+      const lastC1 = getLastLevel("c1", res1.boughtVars);
+      const lastC3 = getLastLevel("c3", res1.boughtVars);
+      const lastC5 = getLastLevel("c5", res1.boughtVars);
+      const sim2 = new t8Sim(data);
+      sim2.milestoneVariant = MX;
+      sim2.ssPoint = ss;
+      sim2.variables[0].setOriginalCap(lastC1)
+      sim2.variables[0].configureCap(13);
+      sim2.variables[2].setOriginalCap(lastC3)
+      sim2.variables[2].configureCap(4);
+      sim2.variables[4].setOriginalCap(lastC5)
+      sim2.variables[4].configureCap(1);
+      res = await sim2.simulate();
+    }
+    return res;
+  }
+
+  let result: simResult;
+  // T8MX and T8MX...SingleMS
+  if ((data.strat.includes("SingleMS") || isMX(data.strat, data.rho))) {
+    const altOptions = data.strat.includes("T8noC3d") ? [0, 2, 3] : [0, 1, 2, 3];
+    let retArr = [];
+
+    if (data.strat.includes("SingleMS")) {
+      let tempResult: simResult;
+      const ssInit = 40;
+      const ssCap = 60;
+      const ssStep = 0.1;
+
+      result = await getResult(data, altOptions[0], ssInit);
+      for (let i = 1; i < altOptions.length; i++) {
+        result = getBestResult(result, await getResult(data, altOptions[i], ssInit));
+      }
+      for (let ssDelta=ssInit+ssStep; ssDelta <= ssCap; ssDelta+=ssStep) {
+        if (result.pubRho < ssDelta) break;
+        tempResult = await getResult(data, altOptions[0], ssDelta)
+        for (let i = 1; i < altOptions.length; i++) {
+          tempResult = getBestResult(result, await getResult(data, altOptions[i], ssDelta));
+        }
+        result = getBestResult(result, tempResult);
+        //if (result !== tempResult) break;
+      }
+    }
+    else {
+      result = await getResult(data, altOptions[0])
+      for (let i = 0; i < altOptions.length; i++) {
+        result = getBestResult(result, await getResult(data, altOptions[i]));
+      }
+    }
   }
   else {
-    let data2: theoryData = JSON.parse(JSON.stringify(data));
-    data2.strat = data2.strat.replace("Coast", "");
-    const sim1 = new t8Sim(data2);
-    const res1 = await sim1.simulate();
-    const lastC1 = getLastLevel("c1", res1.boughtVars);
-    const lastC3 = getLastLevel("c3", res1.boughtVars);
-    const lastC5 = getLastLevel("c5", res1.boughtVars);
-    const sim2 = new t8Sim(data);
-    sim2.variables[0].setOriginalCap(lastC1)
-    sim2.variables[0].configureCap(13);
-    sim2.variables[2].setOriginalCap(lastC3)
-    sim2.variables[2].configureCap(4);
-    sim2.variables[4].setOriginalCap(lastC5)
-    sim2.variables[4].configureCap(1);
-    res = await sim2.simulate();
+    result = await getResult(data);
   }
-  return res;
+  return result;
 }
 
 type theory = "T8";
@@ -44,53 +100,63 @@ class t8Sim extends theoryClass<theory> {
   dy: number;
   dz: number;
   msTimer: number;
+  ssPoint: number;
+  milestoneVariant: number;
 
   getBuyingConditions(): conditionFunction[] {
+    const idleStrat = new Array(5).fill(true);
+    const idleCoastStrat = [
+      () => this.variables[0].shouldBuy,
+      true,
+      () => this.variables[2].shouldBuy,
+      true,
+      () => this.variables[4].shouldBuy,
+    ];
+    const snaxStrat = [
+      () => this.curMult < 1.6,
+      true,
+      () => this.curMult < 2.3,
+      true,
+      () => this.curMult < 2.3
+    ];
+    const dBaseStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, true];
+    const noC3dStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, true];
+    const playStrat = [
+      () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      true,
+      () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      true,
+      () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
+    ];
+    const playCoastStrat = [
+      () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+    ];
+
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
-      T8: [true, true, true, true, true],
+      T8: idleStrat,
+      T8SingleMS: idleStrat,
       T8noC3: [true, true, false, true, true],
       T8noC5: [true, true, true, true, false],
       T8noC35: [true, true, false, true, false],
-      T8Snax: [() => this.curMult < 1.6, true, () => this.curMult < 2.3, true, () => this.curMult < 2.3],
-      T8Coast: [
-        () => this.variables[0].shouldBuy,
-        true,
-        () => this.variables[2].shouldBuy,
-        true,
-        () => this.variables[4].shouldBuy,
-      ],
-      T8noC3d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, true],
+      T8Snax: snaxStrat,
+      T8SnaxSingleMS: snaxStrat,
+      T8Coast: idleCoastStrat,
+      T8SingleMSCoast: idleCoastStrat,
+      T8noC3d: noC3dStrat,
+      T8noC3d2: noC3dStrat,
+      T8noC3dSingleMS: noC3dStrat,
       T8noC5d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, false],
       T8noC35d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, false],
-      T8d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, true],
-      T8Play: [
-        () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
-        true,
-        () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
-        true,
-        () => this.variables[4].cost + l10(4) < Math.min(this.variables[1].cost, this.variables[3].cost),
-      ],
-      T8PlayCoast: [
-        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-        true,
-        () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-        true,
-        () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-      ],
-      T8PlaySolarswap: [
-        () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
-        true,
-        () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
-        true,
-        () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
-      ],
-      T8PlaySolarswapCoast: [
-        () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-        true,
-        () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-        true,
-        () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
-      ]
+      T8d: dBaseStrat,
+      T8dSingleMS: dBaseStrat,
+      T8Play: playStrat,
+      T8PlayCoast: playCoastStrat,
+      T8PlaySolarswap: playStrat,
+      T8PlaySolarswapCoast: playCoastStrat
     };
     return toCallables(conditions[this.strat]);
   }
@@ -99,18 +165,30 @@ class t8Sim extends theoryClass<theory> {
     return conditions;
   }
   getMilestonePriority(): number[] {
-    const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
     switch (this.strat) {
       case "T8noC3": return [0, 2, 3];
-      case "T8noC3d": return [0, 2, 3];
+      case "T8noC3d": return this.milestoneVariant > 0 ? [this.milestoneVariant] : [0, 2, 3];
       case "T8noC5": return [0, 2, 1];
       case "T8noC5d": return [0, 2, 1];
       case "T8noC35": return [0, 2];
       case "T8noC35d": return [0, 2];
     }
-    if (milestoneCount < 3) return [0];
-    else if (milestoneCount == 3) return [3];
-    else return [2, 0, 3, 1];
+
+    const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
+    switch (milestoneCount) {
+      case 2:
+        if (
+          
+          (this.strat.includes("SingleMS") &&
+          this.maxRho >= this.ssPoint)
+        ) {
+          return  [this.milestoneVariant];
+        }
+      case 0:
+      case 1: return [0];
+      case 3: return [3];
+      default: return [2, 0, 3, 1];
+    }
   }
   updateMilestones(): void {
     const prevAttractor = this.milestones[0];
@@ -185,6 +263,8 @@ class t8Sim extends theoryClass<theory> {
       new Variable({ name: "c5", cost: new ExponentialCost(1e2, 1.15 * Math.log2(7), true), valueScaling: new ExponentialValue(7) }),
     ];
     this.msTimer = 0;
+    this.ssPoint = 0;
+    this.milestoneVariant = this.strat.includes("MX") ? 3 : 0;
     this.updateMilestones();
   }
   async simulate(): Promise<simResult> {
@@ -199,10 +279,19 @@ class t8Sim extends theoryClass<theory> {
       if(this.variables[4].shouldFork) await this.doForkVariable(4)
     }
     let stratExtra = "";
-    if(this.strat.includes("Coast")) {
+    if (
+      this.strat.includes("SingleMS")
+      //&& this.maxRho >= this.ssPoint
+    ) {
+      stratExtra += ` ${logToExp(this.ssPoint)}`;
+    }
+    if (this.strat.includes("SingleMS") || (isMX(this.strat, this.maxRho) && this.milestoneVariant > 0)) {
+      stratExtra += ` M${this.milestoneVariant}`;
+    }
+    if (this.strat.includes("Coast")) {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("c1", this.boughtVars)) +
-          this.variables[2].prepareExtraForCap(getLastLevel("c3", this.boughtVars)) +
-          this.variables[4].prepareExtraForCap(getLastLevel("c5", this.boughtVars))
+        this.variables[2].prepareExtraForCap(getLastLevel("c3", this.boughtVars)) +
+        this.variables[4].prepareExtraForCap(getLastLevel("c5", this.boughtVars))
     }
     this.trimBoughtVars();
     return getBestResult(this.createResult(stratExtra), this.bestForkRes);

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -30,7 +30,7 @@ export default async function t8(data: theoryData): Promise<simResult> {
       res = await sim.simulate();
     }
     else {
-      return defaultResult();
+      //return defaultResult();
       let data2: theoryData = JSON.parse(JSON.stringify(data));
       data2.strat = data2.strat.replace("Coast", "");
       const sim1 = new t8Sim(data2, MXVariant, ss);

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -111,7 +111,6 @@ class t8Sim extends theoryClass<theory> {
   msTimer: number;
   ssPoint: number;
   milestoneVariant: number;
-  //isMX: boolean;
 
   getBuyingConditions(): conditionFunction[] {
     const idleStrat = new Array(5).fill(true);
@@ -188,8 +187,7 @@ class t8Sim extends theoryClass<theory> {
 
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       T8: idleStrat,
-      T8M1: idleStrat,
-      T8M3: idleStrat,
+      T8Coast: idleCoastStrat,
       T8noC3: noC3Strat,
       T8noC3Coast: noC3CoastStrat,
       T8noC5: noC5Strat,
@@ -197,9 +195,6 @@ class t8Sim extends theoryClass<theory> {
       T8noC35: noC35Strat,
       T8noC35Coast: noC35CoastStrat,
       T8Snax: snaxStrat,
-      T8Coast: idleCoastStrat,
-      T8M1Coast: idleCoastStrat,
-      T8M3Coast: idleCoastStrat,
       T8noC3d: noC3dStrat,
       T8noC3dCoast: noC3dCoastStrat,
       T8noC3dSingleMS: noC3dStrat,
@@ -222,10 +217,6 @@ class t8Sim extends theoryClass<theory> {
   getMilestonePriority(): number[] {
     const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
     switch (this.strat) {
-      case "T8M1Coast":
-      case "T8M1": return [1, 0, 2];
-      case "T8M3Coast":
-      case "T8M3": return [3, 0];
       case "T8noC3":
       case "T8noC3Coast":
       case "T8noC3dCoast":
@@ -362,7 +353,7 @@ class t8Sim extends theoryClass<theory> {
     this.trimBoughtVars();
     const result = this.createResult(stratExtra);
     if (this.strat.includes("SingleMS")) { //T8NoC3dSingleMS
-      result.strat = `T8M${this.milestoneVariant}${result.strat.slice(2)}`;
+      result.strat = result.strat.replace("SingleMS", `SingleMS${this.milestoneVariant}`);
     }
     return getBestResult(result, this.bestForkRes);
   }

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -5,15 +5,6 @@ import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost, parseValue } from '../../Utils/cost';
 import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult, logToExp, defaultResult } from "../../Utils/helpers";
 
-// T8NoC3dSingleMS
-const ssPoints = [
-  [ 
-    ...Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53)),
-    ...Array.from({length: 86-44+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 44))
-  ].toSorted((a,b) => a - b),
-  Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53))
-];
-
 export default async function t8(data: theoryData): Promise<simResult> {
   console.log(data);
   async function getResult (
@@ -50,22 +41,22 @@ export default async function t8(data: theoryData): Promise<simResult> {
   // T8noC3dSingleMS
   if (data.strat.includes("T8noC3dSingleMS")) {
     if (data.rho < 50) {
-      const ssPoints = [
+      const singleSwapPoints = [
         Array.from({length: 66}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
         Array.from({length: 55}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
       ];
       const MXVariantOptions = data.rho > 40 ? [3] : [2, 3];
       for (const MXVariant of MXVariantOptions) {
         // Only Swap points within e5 of recovery
-        for (const ssPoint of ssPoints[MXVariant-2].filter(
+        for (const singleSwapPoint of singleSwapPoints[MXVariant-2].filter(
           (num) => (num > data.rho - 5) && (num <= data.rho)
         )) {
-          result = getBestResult(result, await getResult(data, MXVariant, ssPoint));
+          result = getBestResult(result, await getResult(data, MXVariant, singleSwapPoint));
         }
       }
     }
     else {
-      const ssPoints = [
+      const singleSwapPoints = [
         [ 
           ...Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53)),
           ...Array.from({length: 86-44+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 44))
@@ -75,7 +66,7 @@ export default async function t8(data: theoryData): Promise<simResult> {
       const MXVariantOptions = data.rho > 59 ? [2] : (data.rho < 55 ? [0] : [0, 2]);
       for (const MXVariant of MXVariantOptions) {
         // Only Swap points within e5 of recovery (except M2 before e57)
-        for (const ssPoint of ssPoints[MXVariant/2].filter(
+        for (const singleSwapPoint of singleSwapPoints[MXVariant/2].filter(
           (num) => {
             return (num > data.rho - 5)
               && (
@@ -84,8 +75,8 @@ export default async function t8(data: theoryData): Promise<simResult> {
               );
           }
         )) {
-          result = getBestResult(result, await getResult(data, MXVariant, ssPoint));
-          if (result.pubRho < ssPoint) break;
+          result = getBestResult(result, await getResult(data, MXVariant, singleSwapPoint));
+          if (result.pubRho < singleSwapPoint) break;
         }
       }
     }
@@ -109,7 +100,7 @@ class t8Sim extends theoryClass<theory> {
   dy: number;
   dz: number;
   msTimer: number;
-  ssPoint: number;
+  singleSwapPoint: number;
   milestoneVariant: number;
 
   getBuyingConditions(): conditionFunction[] {
@@ -175,9 +166,23 @@ class t8Sim extends theoryClass<theory> {
       true,
       () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
       true,
-      () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      () => this.variables[4].cost + l10(4) < Math.min(this.variables[1].cost, this.variables[3].cost),
     ];
     const playCoastStrat = [
+      () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      () => this.variables[4].shouldBuy && (this.variables[4].cost + l10(4) < Math.min(this.variables[1].cost, this.variables[3].cost)),
+    ];
+    const playSolarswapStrat = [
+      () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      true,
+      () => this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
+      true,
+      () => this.variables[4].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost),
+    ];
+    const playSolarswapCoastStrat = [
       () => this.variables[0].shouldBuy && (this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost)),
       true,
       () => this.variables[2].shouldBuy && (this.variables[2].cost + l10(2.5) < Math.min(this.variables[1].cost, this.variables[3].cost)),
@@ -205,8 +210,8 @@ class t8Sim extends theoryClass<theory> {
       T8noC35dCoast: noC35dStrat,
       T8Play: playStrat,
       T8PlayCoast: playCoastStrat,
-      T8PlaySolarswap: playStrat,
-      T8PlaySolarswapCoast: playCoastStrat
+      T8PlaySolarswap: playSolarswapStrat,
+      T8PlaySolarswapCoast: playSolarswapCoastStrat
     };
     return toCallables(conditions[this.strat]);
   }
@@ -224,9 +229,9 @@ class t8Sim extends theoryClass<theory> {
       case "T8noC3dSingleMSCoast":
       case "T8noC3dSingleMS":
         if (Math.max(this.maxRho, this.lastPub) < 50) {
-          return this.maxRho < this.ssPoint ? [this.milestoneVariant] : [0];
+          return this.maxRho < this.singleSwapPoint ? [this.milestoneVariant] : [0];
         }
-        return this.maxRho < this.ssPoint ? [this.milestoneVariant, 0, 3, 2] : [3, 0, 2];
+        return this.maxRho < this.singleSwapPoint ? [this.milestoneVariant, 0, 3, 2] : [3, 0, 2];
       case "T8noC5":
       case "T8noC5Coast":
       case "T8noC5dCoast":
@@ -277,7 +282,7 @@ class t8Sim extends theoryClass<theory> {
   constructor(
     data: theoryData,
     milestoneVariant: number = 0,
-    ssPoint: number = 0
+    singleSwapPoint: number = 0
   ) {
     super(data);
     //attractor stuff
@@ -323,7 +328,7 @@ class t8Sim extends theoryClass<theory> {
     ];
     this.msTimer = 0;
     this.milestoneVariant = milestoneVariant;
-    this.ssPoint = ssPoint;
+    this.singleSwapPoint = singleSwapPoint;
     this.updateMilestones();
   }
   async simulate(): Promise<simResult> {
@@ -339,7 +344,7 @@ class t8Sim extends theoryClass<theory> {
     }
     let stratExtra = "";
     if (this.strat.includes("SingleMS")) {
-      stratExtra += ` ${logToExp(this.ssPoint,2)}`;
+      stratExtra += ` ${logToExp(this.singleSwapPoint,2)}`;
     }
     if (this.strat.includes("Coast")) {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("c1", this.boughtVars));
@@ -419,7 +424,7 @@ class t8Sim extends theoryClass<theory> {
     this.dz = other.dz;
     this.msTimer = other.msTimer;
     this.milestoneVariant = other.milestoneVariant;
-    this.ssPoint = other.ssPoint;
+    this.singleSwapPoint = other.singleSwapPoint;
   }
   copy() {
     let copySim = new t8Sim(this.getDataForCopy());

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -10,22 +10,22 @@ export default async function t8(data: theoryData): Promise<simResult> {
   async function getResult (
     data: theoryData,
     MXVariant: number = 0,
-    ssPoint: number = 0
+    singleSwapPoint: number = 0
   ): Promise<simResult> {
     let res;
     if (!data.strat.includes("Coast")) {
-      const sim = new t8Sim(data, MXVariant, ssPoint);
+      const sim = new t8Sim(data, MXVariant, singleSwapPoint);
       res = await sim.simulate();
     }
     else {
       let data2: theoryData = JSON.parse(JSON.stringify(data));
       data2.strat = data2.strat.replace("Coast", "");
-      const sim1 = new t8Sim(data2, MXVariant, ssPoint);
+      const sim1 = new t8Sim(data2, MXVariant, singleSwapPoint);
       const res1 = await sim1.simulate();
       const lastC1 = getLastLevel("c1", res1.boughtVars);
       const lastC3 = getLastLevel("c3", res1.boughtVars);
       const lastC5 = getLastLevel("c5", res1.boughtVars);
-      const sim2 = new t8Sim(data, MXVariant, ssPoint);
+      const sim2 = new t8Sim(data, MXVariant, singleSwapPoint);
       sim2.variables[0].setOriginalCap(lastC1)
       sim2.variables[0].configureCap(13);
       sim2.variables[2].setOriginalCap(lastC3)
@@ -40,46 +40,30 @@ export default async function t8(data: theoryData): Promise<simResult> {
   let result: simResult = defaultResult();
   // T8noC3dSingleMS
   if (data.strat.includes("T8noC3dSingleMS")) {
-    if (data.rho < 50) {
-      const singleSwapPoints = [
-        Array.from({length: 66}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
-        Array.from({length: 55}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
-      ];
-      const MXVariantOptions = data.rho > 40 ? [3] : [2, 3];
-      for (const MXVariant of MXVariantOptions) {
-        // Only Swap points within e5 of recovery
-        for (const singleSwapPoint of singleSwapPoints[MXVariant-2].filter(
-          (num) => (num > data.rho - 5) && (num <= data.rho)
-        )) {
-          result = getBestResult(result, await getResult(data, MXVariant, singleSwapPoint));
+    const singleSwapPoints = [
+      [ 
+        ...Array.from({length: 104-53+1}, (_, lvl) => l10(1e2) + (l10(2) * (1.15 * Math.log2(5)) * (lvl + 53))),
+        ...Array.from({length: 86-44+1}, (_, lvl) => l10(1e2) + (l10(2) * (1.15 * Math.log2(7)) * (lvl + 44)))
+      ].toSorted((a,b) => a - b),
+      Array.from({length: 104-53+1}, (_, lvl) => l10(1e2) + (l10(2) * (1.15 * Math.log2(5))) * (lvl + 53))
+    ];
+    const MXVariantOptions = data.rho > 59 ? [2] : (data.rho < 55 ? [0] : [0, 2]);
+    for (const MXVariant of MXVariantOptions) {
+      // Only Swap points within e5 of recovery (except M2 before e57)
+      for (const singleSwapPoint of singleSwapPoints[MXVariant/2].filter(
+        (num) => {
+          return (num > data.rho - 5)
+            && (
+              (num <= data.rho)
+              || ((data.rho <= 57) && (MXVariant === 2))
+            );
         }
+      )) {
+        result = getBestResult(result, await getResult(data, MXVariant, singleSwapPoint));
+        if (result.pubRho < singleSwapPoint) break;
       }
     }
-    else {
-      const singleSwapPoints = [
-        [ 
-          ...Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53)),
-          ...Array.from({length: 86-44+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 44))
-        ].toSorted((a,b) => a - b),
-        Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53))
-      ];
-      const MXVariantOptions = data.rho > 59 ? [2] : (data.rho < 55 ? [0] : [0, 2]);
-      for (const MXVariant of MXVariantOptions) {
-        // Only Swap points within e5 of recovery (except M2 before e57)
-        for (const singleSwapPoint of singleSwapPoints[MXVariant/2].filter(
-          (num) => {
-            return (num > data.rho - 5)
-              && (
-                (num <= data.rho)
-                || ((data.rho <= 57) && (MXVariant === 2))
-              );
-          }
-        )) {
-          result = getBestResult(result, await getResult(data, MXVariant, singleSwapPoint));
-          if (result.pubRho < singleSwapPoint) break;
-        }
-      }
-    }
+    
   }
   else {
     result = await getResult(data);
@@ -228,9 +212,6 @@ class t8Sim extends theoryClass<theory> {
       case "T8noC3d": return Math.max(this.maxRho, this.lastPub) < 50 ? [0] : [3, 0, 2];
       case "T8noC3dSingleMSCoast":
       case "T8noC3dSingleMS":
-        if (Math.max(this.maxRho, this.lastPub) < 50) {
-          return this.maxRho < this.singleSwapPoint ? [this.milestoneVariant] : [0];
-        }
         return this.maxRho < this.singleSwapPoint ? [this.milestoneVariant, 0, 3, 2] : [3, 0, 2];
       case "T8noC5":
       case "T8noC5Coast":

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -5,40 +5,36 @@ import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
 import { ExponentialCost, FirstFreeCost, parseValue } from '../../Utils/cost';
 import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult, logToExp, defaultResult } from "../../Utils/helpers";
 
-//106-70, 73-48, 60-40
+// T8NoC3dSingleMS
 const ssPoints = [
-  [ // For T8noC3d
-    ...Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
-    ...Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
+  [ 
+    ...Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53)),
+    ...Array.from({length: 86-44+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 44))
   ].toSorted((a,b) => a - b),
-  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(3))))) * (lvl + 1)),
-  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
-  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
+  Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53))
 ];
-console.log(ssPoints);
 
 export default async function t8(data: theoryData): Promise<simResult> {
   console.log(data);
   async function getResult (
     data: theoryData,
     MXVariant: number = 0,
-    ss: number = 0
+    ssPoint: number = 0
   ): Promise<simResult> {
     let res;
     if (!data.strat.includes("Coast")) {
-      const sim = new t8Sim(data, MXVariant, ss);
+      const sim = new t8Sim(data, MXVariant, ssPoint);
       res = await sim.simulate();
     }
     else {
-      //return defaultResult();
       let data2: theoryData = JSON.parse(JSON.stringify(data));
       data2.strat = data2.strat.replace("Coast", "");
-      const sim1 = new t8Sim(data2, MXVariant, ss);
+      const sim1 = new t8Sim(data2, MXVariant, ssPoint);
       const res1 = await sim1.simulate();
       const lastC1 = getLastLevel("c1", res1.boughtVars);
       const lastC3 = getLastLevel("c3", res1.boughtVars);
       const lastC5 = getLastLevel("c5", res1.boughtVars);
-      const sim2 = new t8Sim(data, MXVariant, ss);
+      const sim2 = new t8Sim(data, MXVariant, ssPoint);
       sim2.variables[0].setOriginalCap(lastC1)
       sim2.variables[0].configureCap(13);
       sim2.variables[2].setOriginalCap(lastC3)
@@ -51,27 +47,48 @@ export default async function t8(data: theoryData): Promise<simResult> {
   }
 
   let result: simResult = defaultResult();
-  // MX and SingleMS
-  if (data.strat.includes("SingleMS")) {
-    const altOptions = (data.strat.includes("T8noC3d")
-      ? (data.rho < 50 ? [2, 3] : [0, 2]) // See getMilestonePriority()
-      : (data.strat.includes("T8noC35d")
-        ? [2]
-        : [1, 2, 3]
-      )
-    );
-    console.log(data.strat);
-    // Remove default MX option for SingleMS (equivalent to base strat)
-    for (const option of altOptions) {
-      // Only Swap points within e5 of recovery
-      for (const ssPoint of ssPoints[option].filter((num) => num > data.rho - 5)) {
-        const r = await getResult(data, option, ssPoint)
-        result = getBestResult(result, r);
-        if (result.pubRho < ssPoint) break;
-        if (result != r) break;
+  // T8noC3dSingleMS
+  if (data.strat.includes("T8noC3dSingleMS")) {
+    if (data.rho < 50) {
+      const ssPoints = [
+        Array.from({length: 66}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
+        Array.from({length: 55}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
+      ];
+      const MXVariantOptions = data.rho > 40 ? [3] : [2, 3];
+      for (const MXVariant of MXVariantOptions) {
+        // Only Swap points within e5 of recovery
+        for (const ssPoint of ssPoints[MXVariant-2].filter(
+          (num) => (num > data.rho - 5) && (num <= data.rho)
+        )) {
+          result = getBestResult(result, await getResult(data, MXVariant, ssPoint));
+        }
       }
     }
-    console.log(result);
+    else {
+      const ssPoints = [
+        [ 
+          ...Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53)),
+          ...Array.from({length: 86-44+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 44))
+        ].toSorted((a,b) => a - b),
+        Array.from({length: 104-53+1}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 53))
+      ];
+      const MXVariantOptions = data.rho > 59 ? [2] : (data.rho < 55 ? [0] : [0, 2]);
+      for (const MXVariant of MXVariantOptions) {
+        // Only Swap points within e5 of recovery (except M2 before e57)
+        for (const ssPoint of ssPoints[MXVariant/2].filter(
+          (num) => {
+            return (num > data.rho - 5)
+              && (
+                (num <= data.rho)
+                || ((data.rho <= 57) && (MXVariant === 2))
+              );
+          }
+        )) {
+          result = getBestResult(result, await getResult(data, MXVariant, ssPoint));
+          if (result.pubRho < ssPoint) break;
+        }
+      }
+    }
   }
   else {
     result = await getResult(data);
@@ -104,6 +121,31 @@ class t8Sim extends theoryClass<theory> {
       () => this.variables[2].shouldBuy,
       true,
       () => this.variables[4].shouldBuy,
+    ];
+    
+    const noC3Strat = [true, true, false, true, true];
+    const noC3CoastStrat = [
+      () => this.variables[0].shouldBuy,
+      true,
+      false,
+      true,
+      () => this.variables[4].shouldBuy,
+    ];
+    const noC5Strat = [true, true, true, true, false];
+    const noC5CoastStrat = [
+      () => this.variables[0].shouldBuy,
+      true,
+      () => this.variables[2].shouldBuy,
+      true,
+      false,
+    ];
+    const noC35Strat = [true, true, false, true, false];
+    const noC35CoastStrat = [
+      () => this.variables[0].shouldBuy,
+      true,
+      false,
+      true,
+      false,
     ];
     const snaxStrat = [
       () => this.curMult < 1.6,
@@ -146,14 +188,18 @@ class t8Sim extends theoryClass<theory> {
 
     const conditions: Record<stratType[theory], (boolean | conditionFunction)[]> = {
       T8: idleStrat,
-      T8SingleMS: idleStrat,
-      T8noC3: [true, true, false, true, true],
-      T8noC5: [true, true, true, true, false],
-      T8noC35: [true, true, false, true, false],
+      T8M1: idleStrat,
+      T8M3: idleStrat,
+      T8noC3: noC3Strat,
+      T8noC3Coast: noC3CoastStrat,
+      T8noC5: noC5Strat,
+      T8noC5Coast: noC5CoastStrat,
+      T8noC35: noC35Strat,
+      T8noC35Coast: noC35CoastStrat,
       T8Snax: snaxStrat,
-      T8SnaxSingleMS: snaxStrat,
       T8Coast: idleCoastStrat,
-      T8SingleMSCoast: idleCoastStrat,
+      T8M1Coast: idleCoastStrat,
+      T8M3Coast: idleCoastStrat,
       T8noC3d: noC3dStrat,
       T8noC3dCoast: noC3dCoastStrat,
       T8noC3dSingleMS: noC3dStrat,
@@ -161,10 +207,9 @@ class t8Sim extends theoryClass<theory> {
       T8noC5d: noC5dStrat,
       T8noC5dCoast: noC5dCoastStrat,
       T8noC35d: noC35dStrat,
+      T8noC35dCoast: noC35dStrat,
       T8Play: playStrat,
-      T8PlaySingleMS: playStrat,
       T8PlayCoast: playCoastStrat,
-      T8PlaySingleMSCoast: playCoastStrat,
       T8PlaySolarswap: playStrat,
       T8PlaySolarswapCoast: playCoastStrat
     };
@@ -176,54 +221,38 @@ class t8Sim extends theoryClass<theory> {
   }
   getMilestonePriority(): number[] {
     const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
-    const maxRho = Math.max(this.maxRho, this.lastPub);
     switch (this.strat) {
-      case "T8Coast":
-      case "T8":
-        if (maxRho < 52) return [0];
-        else if (maxRho < 80) return [3, 0];
-        else if (maxRho < 160 && maxRho >= 220) return [2, 0, 3, 1];
-        return [1, 0, 2, 3];
-      // TODO: Split this strat into 2 seperate named strats for clarity
+      case "T8M1Coast":
+      case "T8M1": return [1, 0, 2];
+      case "T8M3Coast":
+      case "T8M3": return [3, 0];
       case "T8noC3":
+      case "T8noC3Coast":
       case "T8noC3dCoast":
-      case "T8noC3d":  return maxRho < 50 ? [0] : [3, 0, 2];
+      case "T8noC3d": return Math.max(this.maxRho, this.lastPub) < 50 ? [0] : [3, 0, 2];
       case "T8noC3dSingleMSCoast":
       case "T8noC3dSingleMS":
-        if (maxRho < 50) {
+        if (Math.max(this.maxRho, this.lastPub) < 50) {
           return this.maxRho < this.ssPoint ? [this.milestoneVariant] : [0];
         }
         return this.maxRho < this.ssPoint ? [this.milestoneVariant, 0, 3, 2] : [3, 0, 2];
       case "T8noC5":
+      case "T8noC5Coast":
       case "T8noC5dCoast":
       case "T8noC5d": return [0, 2, 1];
       case "T8noC35":
+      case "T8noC35Coast":
+      case "T8noC35dCoast":
       case "T8noC35d": return [2, 0];
-      case "T8Snax":
-        if (maxRho < 60) return [0];
-        else if (maxRho < 80) return [3];
-        else if (maxRho < 160) return [2, 0, 3];
-        return [1, 0, 2, 3];
       case "T8Play":
       case "T8PlayCoast": return milestoneCount < 4 ? [0, 3] : [2, 0, 3, 1];
       case "T8PlaySolarswap":
       case "T8PlaySolarswapCoast": return milestoneCount < 4 ? [0, 3] : [0, 2, 3, 1];
     }
 
-    switch (milestoneCount) {
-      case 0:
-      case 1:
-      case 2: return (this.strat.includes("SingleMS") && this.maxRho < this.ssPoint) ? [0] : [this.milestoneVariant];
-      case 3:
-        if (this.strat.includes("SingleMS")) {
-          return (this.maxRho < this.ssPoint
-            ? [0, this.milestoneVariant]
-            : [this.milestoneVariant]
-          );
-        }
-        return [3];
-      default: return (this.strat.includes("SingleMS") && this.maxRho < this.ssPoint) ? [this.milestoneVariant] : [2, 0, 3, 1];
-    }
+    if (milestoneCount < 3) return [0];
+    else if (milestoneCount == 3) return [3];
+    else return [2, 0, 3, 1];
   }
   updateMilestones(): void {
     const prevAttractor = this.milestones[0];
@@ -302,7 +331,6 @@ class t8Sim extends theoryClass<theory> {
       new Variable({ name: "c5", cost: new ExponentialCost(1e2, 1.15 * Math.log2(7), true), valueScaling: new ExponentialValue(7) }),
     ];
     this.msTimer = 0;
-    //this.isMX = isMX(this.strat, this.lastPub);
     this.milestoneVariant = milestoneVariant;
     this.ssPoint = ssPoint;
     this.updateMilestones();
@@ -322,10 +350,6 @@ class t8Sim extends theoryClass<theory> {
     if (this.strat.includes("SingleMS")) {
       stratExtra += ` ${logToExp(this.ssPoint,2)}`;
     }
-    //this.isMX = isMX(this.strat, this.pubRho);
-    /*if (this.isMX) {
-      stratExtra += ` M${this.milestoneVariant}`;
-    }*/
     if (this.strat.includes("Coast")) {
       stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("c1", this.boughtVars));
       if (!this.strat.includes("noC3") && !this.strat.includes("noC35")) {
@@ -336,7 +360,11 @@ class t8Sim extends theoryClass<theory> {
       }
     }
     this.trimBoughtVars();
-    return getBestResult(this.createResult(stratExtra), this.bestForkRes);
+    const result = this.createResult(stratExtra);
+    if (this.strat.includes("SingleMS")) { //T8NoC3dSingleMS
+      result.strat = `T8M${this.milestoneVariant}${result.strat.slice(2)}`;
+    }
+    return getBestResult(result, this.bestForkRes);
   }
   tick() {
     this.dn();
@@ -386,7 +414,6 @@ class t8Sim extends theoryClass<theory> {
 
     const rhodot = l10(this.dt) + this.totMult + this.variables[0].value + this.variables[1].value + add(dx2Term, dy2Term, dz2Term) / 2 - 2;
     this.rho.add(rhodot);
-    //if (!this.isMX) this.isMX = isMX(this.strat, Math.max(this.rho.value, this.lastPub));
   }
   copyFrom(other: this) {
     super.copyFrom(other);
@@ -400,7 +427,6 @@ class t8Sim extends theoryClass<theory> {
     this.dy = other.dy;
     this.dz = other.dz;
     this.msTimer = other.msTimer;
-    //this.isMX = other.isMX;
     this.milestoneVariant = other.milestoneVariant;
     this.ssPoint = other.ssPoint;
   }

--- a/src/Theories/T1-T8/T8.ts
+++ b/src/Theories/T1-T8/T8.ts
@@ -2,41 +2,43 @@ import { global } from "../../Sim/main";
 import theoryClass from "../theory";
 import Variable from "../../Utils/variable";
 import { ExponentialValue, StepwisePowerSumValue } from "../../Utils/value";
-import { ExponentialCost, FirstFreeCost } from '../../Utils/cost';
-import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult, logToExp } from "../../Utils/helpers";
+import { ExponentialCost, FirstFreeCost, parseValue } from '../../Utils/cost';
+import { add, l10, getR9multiplier, toCallables, getLastLevel, getBestResult, logToExp, defaultResult } from "../../Utils/helpers";
 
-const MXStrats = ["T8", "T8Coast", "T8Snax", "T8d", "T8noC3d"];
-const isMX = (strat: string, rho: number) => (
-  rho >= 37
-  && rho < 60
-  && (
-    strat.includes("SingleMS")
-    || MXStrats.includes(strat)
-  )
-);
+//106-70, 73-48, 60-40
+const ssPoints = [
+  [ // For T8noC3d
+    ...Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
+    ...Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
+  ].toSorted((a,b) => a - b),
+  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(3))))) * (lvl + 1)),
+  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(5))))) * (lvl + 1)),
+  Array.from({length: 400}, (_, lvl) => parseValue(String(1e2)) + (l10(2) * 10**parseValue(String((1.15 * Math.log2(7))))) * (lvl + 1))
+];
+console.log(ssPoints);
 
 export default async function t8(data: theoryData): Promise<simResult> {
-  async function getResult (data: theoryData, MX: number = 0, ss: number = 0): Promise<simResult> {
+  console.log(data);
+  async function getResult (
+    data: theoryData,
+    MXVariant: number = 0,
+    ss: number = 0
+  ): Promise<simResult> {
     let res;
     if (!data.strat.includes("Coast")) {
-      const sim = new t8Sim(data);
-      sim.milestoneVariant = MX;
-      sim.ssPoint = ss;
+      const sim = new t8Sim(data, MXVariant, ss);
       res = await sim.simulate();
     }
     else {
+      return defaultResult();
       let data2: theoryData = JSON.parse(JSON.stringify(data));
       data2.strat = data2.strat.replace("Coast", "");
-      const sim1 = new t8Sim(data2);
-      sim1.milestoneVariant = MX;
-      sim1.ssPoint = ss;
+      const sim1 = new t8Sim(data2, MXVariant, ss);
       const res1 = await sim1.simulate();
       const lastC1 = getLastLevel("c1", res1.boughtVars);
       const lastC3 = getLastLevel("c3", res1.boughtVars);
       const lastC5 = getLastLevel("c5", res1.boughtVars);
-      const sim2 = new t8Sim(data);
-      sim2.milestoneVariant = MX;
-      sim2.ssPoint = ss;
+      const sim2 = new t8Sim(data, MXVariant, ss);
       sim2.variables[0].setOriginalCap(lastC1)
       sim2.variables[0].configureCap(13);
       sim2.variables[2].setOriginalCap(lastC3)
@@ -48,38 +50,28 @@ export default async function t8(data: theoryData): Promise<simResult> {
     return res;
   }
 
-  let result: simResult;
-  // T8MX and T8MX...SingleMS
-  if ((data.strat.includes("SingleMS") || isMX(data.strat, data.rho))) {
-    const altOptions = data.strat.includes("T8noC3d") ? [0, 2, 3] : [0, 1, 2, 3];
-    let retArr = [];
-
-    if (data.strat.includes("SingleMS")) {
-      let tempResult: simResult;
-      const ssInit = 40;
-      const ssCap = 60;
-      const ssStep = 0.1;
-
-      result = await getResult(data, altOptions[0], ssInit);
-      for (let i = 1; i < altOptions.length; i++) {
-        result = getBestResult(result, await getResult(data, altOptions[i], ssInit));
-      }
-      for (let ssDelta=ssInit+ssStep; ssDelta <= ssCap; ssDelta+=ssStep) {
-        if (result.pubRho < ssDelta) break;
-        tempResult = await getResult(data, altOptions[0], ssDelta)
-        for (let i = 1; i < altOptions.length; i++) {
-          tempResult = getBestResult(result, await getResult(data, altOptions[i], ssDelta));
-        }
-        result = getBestResult(result, tempResult);
-        //if (result !== tempResult) break;
+  let result: simResult = defaultResult();
+  // MX and SingleMS
+  if (data.strat.includes("SingleMS")) {
+    const altOptions = (data.strat.includes("T8noC3d")
+      ? (data.rho < 50 ? [2, 3] : [0, 2]) // See getMilestonePriority()
+      : (data.strat.includes("T8noC35d")
+        ? [2]
+        : [1, 2, 3]
+      )
+    );
+    console.log(data.strat);
+    // Remove default MX option for SingleMS (equivalent to base strat)
+    for (const option of altOptions) {
+      // Only Swap points within e5 of recovery
+      for (const ssPoint of ssPoints[option].filter((num) => num > data.rho - 5)) {
+        const r = await getResult(data, option, ssPoint)
+        result = getBestResult(result, r);
+        if (result.pubRho < ssPoint) break;
+        if (result != r) break;
       }
     }
-    else {
-      result = await getResult(data, altOptions[0])
-      for (let i = 0; i < altOptions.length; i++) {
-        result = getBestResult(result, await getResult(data, altOptions[i]));
-      }
-    }
+    console.log(result);
   }
   else {
     result = await getResult(data);
@@ -102,6 +94,7 @@ class t8Sim extends theoryClass<theory> {
   msTimer: number;
   ssPoint: number;
   milestoneVariant: number;
+  //isMX: boolean;
 
   getBuyingConditions(): conditionFunction[] {
     const idleStrat = new Array(5).fill(true);
@@ -119,8 +112,23 @@ class t8Sim extends theoryClass<theory> {
       true,
       () => this.curMult < 2.3
     ];
-    const dBaseStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, true];
     const noC3dStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, true];
+    const noC3dCoastStrat = [
+      () => this.variables[0].shouldBuy && (this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      false,
+      true,
+      () => this.variables[4].shouldBuy
+    ];
+    const noC5dStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, false];
+    const noC5dCoastStrat = [
+      () => this.variables[0].shouldBuy && (this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost)),
+      true,
+      () => this.variables[4].shouldBuy,
+      true,
+      false
+    ];
+    const noC35dStrat = [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, false];
     const playStrat = [
       () => this.variables[0].cost + l10(8) < Math.min(this.variables[1].cost, this.variables[3].cost),
       true,
@@ -147,14 +155,16 @@ class t8Sim extends theoryClass<theory> {
       T8Coast: idleCoastStrat,
       T8SingleMSCoast: idleCoastStrat,
       T8noC3d: noC3dStrat,
-      T8noC3d2: noC3dStrat,
+      T8noC3dCoast: noC3dCoastStrat,
       T8noC3dSingleMS: noC3dStrat,
-      T8noC5d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, true, true, false],
-      T8noC35d: [() => this.variables[0].cost + 1 < Math.min(this.variables[1].cost, this.variables[3].cost), true, false, true, false],
-      T8d: dBaseStrat,
-      T8dSingleMS: dBaseStrat,
+      T8noC3dSingleMSCoast: noC3dCoastStrat,
+      T8noC5d: noC5dStrat,
+      T8noC5dCoast: noC5dCoastStrat,
+      T8noC35d: noC35dStrat,
       T8Play: playStrat,
+      T8PlaySingleMS: playStrat,
       T8PlayCoast: playCoastStrat,
+      T8PlaySingleMSCoast: playCoastStrat,
       T8PlaySolarswap: playStrat,
       T8PlaySolarswapCoast: playCoastStrat
     };
@@ -165,29 +175,54 @@ class t8Sim extends theoryClass<theory> {
     return conditions;
   }
   getMilestonePriority(): number[] {
+    const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
+    const maxRho = Math.max(this.maxRho, this.lastPub);
     switch (this.strat) {
-      case "T8noC3": return [0, 2, 3];
-      case "T8noC3d": return this.milestoneVariant > 0 ? [this.milestoneVariant] : [0, 2, 3];
-      case "T8noC5": return [0, 2, 1];
+      case "T8Coast":
+      case "T8":
+        if (maxRho < 52) return [0];
+        else if (maxRho < 80) return [3, 0];
+        else if (maxRho < 160 && maxRho >= 220) return [2, 0, 3, 1];
+        return [1, 0, 2, 3];
+      // TODO: Split this strat into 2 seperate named strats for clarity
+      case "T8noC3":
+      case "T8noC3dCoast":
+      case "T8noC3d":  return maxRho < 50 ? [0] : [3, 0, 2];
+      case "T8noC3dSingleMSCoast":
+      case "T8noC3dSingleMS":
+        if (maxRho < 50) {
+          return this.maxRho < this.ssPoint ? [this.milestoneVariant] : [0];
+        }
+        return this.maxRho < this.ssPoint ? [this.milestoneVariant, 0, 3, 2] : [3, 0, 2];
+      case "T8noC5":
+      case "T8noC5dCoast":
       case "T8noC5d": return [0, 2, 1];
-      case "T8noC35": return [0, 2];
-      case "T8noC35d": return [0, 2];
+      case "T8noC35":
+      case "T8noC35d": return [2, 0];
+      case "T8Snax":
+        if (maxRho < 60) return [0];
+        else if (maxRho < 80) return [3];
+        else if (maxRho < 160) return [2, 0, 3];
+        return [1, 0, 2, 3];
+      case "T8Play":
+      case "T8PlayCoast": return milestoneCount < 4 ? [0, 3] : [2, 0, 3, 1];
+      case "T8PlaySolarswap":
+      case "T8PlaySolarswapCoast": return milestoneCount < 4 ? [0, 3] : [0, 2, 3, 1];
     }
 
-    const milestoneCount = Math.min(11, Math.floor(Math.max(this.lastPub, this.maxRho) / 20));
     switch (milestoneCount) {
-      case 2:
-        if (
-          
-          (this.strat.includes("SingleMS") &&
-          this.maxRho >= this.ssPoint)
-        ) {
-          return  [this.milestoneVariant];
-        }
       case 0:
-      case 1: return [0];
-      case 3: return [3];
-      default: return [2, 0, 3, 1];
+      case 1:
+      case 2: return (this.strat.includes("SingleMS") && this.maxRho < this.ssPoint) ? [0] : [this.milestoneVariant];
+      case 3:
+        if (this.strat.includes("SingleMS")) {
+          return (this.maxRho < this.ssPoint
+            ? [0, this.milestoneVariant]
+            : [this.milestoneVariant]
+          );
+        }
+        return [3];
+      default: return (this.strat.includes("SingleMS") && this.maxRho < this.ssPoint) ? [this.milestoneVariant] : [2, 0, 3, 1];
     }
   }
   updateMilestones(): void {
@@ -219,7 +254,11 @@ class t8Sim extends theoryClass<theory> {
       this.dz = 500 * (0.1 + iz * (ix - 14));
     }
   }
-  constructor(data: theoryData) {
+  constructor(
+    data: theoryData,
+    milestoneVariant: number = 0,
+    ssPoint: number = 0
+  ) {
     super(data);
     //attractor stuff
     this.bounds = [
@@ -263,8 +302,9 @@ class t8Sim extends theoryClass<theory> {
       new Variable({ name: "c5", cost: new ExponentialCost(1e2, 1.15 * Math.log2(7), true), valueScaling: new ExponentialValue(7) }),
     ];
     this.msTimer = 0;
-    this.ssPoint = 0;
-    this.milestoneVariant = this.strat.includes("MX") ? 3 : 0;
+    //this.isMX = isMX(this.strat, this.lastPub);
+    this.milestoneVariant = milestoneVariant;
+    this.ssPoint = ssPoint;
     this.updateMilestones();
   }
   async simulate(): Promise<simResult> {
@@ -279,19 +319,21 @@ class t8Sim extends theoryClass<theory> {
       if(this.variables[4].shouldFork) await this.doForkVariable(4)
     }
     let stratExtra = "";
-    if (
-      this.strat.includes("SingleMS")
-      //&& this.maxRho >= this.ssPoint
-    ) {
-      stratExtra += ` ${logToExp(this.ssPoint)}`;
+    if (this.strat.includes("SingleMS")) {
+      stratExtra += ` ${logToExp(this.ssPoint,2)}`;
     }
-    if (this.strat.includes("SingleMS") || (isMX(this.strat, this.maxRho) && this.milestoneVariant > 0)) {
+    //this.isMX = isMX(this.strat, this.pubRho);
+    /*if (this.isMX) {
       stratExtra += ` M${this.milestoneVariant}`;
-    }
+    }*/
     if (this.strat.includes("Coast")) {
-      stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("c1", this.boughtVars)) +
-        this.variables[2].prepareExtraForCap(getLastLevel("c3", this.boughtVars)) +
-        this.variables[4].prepareExtraForCap(getLastLevel("c5", this.boughtVars))
+      stratExtra += this.variables[0].prepareExtraForCap(getLastLevel("c1", this.boughtVars));
+      if (!this.strat.includes("noC3") && !this.strat.includes("noC35")) {
+        stratExtra += this.variables[2].prepareExtraForCap(getLastLevel("c3", this.boughtVars));
+      }
+      if (!this.strat.includes("noC5") && !this.strat.includes("noC35")) {
+        stratExtra += this.variables[4].prepareExtraForCap(getLastLevel("c5", this.boughtVars));
+      }
     }
     this.trimBoughtVars();
     return getBestResult(this.createResult(stratExtra), this.bestForkRes);
@@ -344,9 +386,13 @@ class t8Sim extends theoryClass<theory> {
 
     const rhodot = l10(this.dt) + this.totMult + this.variables[0].value + this.variables[1].value + add(dx2Term, dy2Term, dz2Term) / 2 - 2;
     this.rho.add(rhodot);
+    //if (!this.isMX) this.isMX = isMX(this.strat, Math.max(this.rho.value, this.lastPub));
   }
   copyFrom(other: this) {
     super.copyFrom(other);
+    this.bounds = other.bounds;
+    this.defaultStates = other.defaultStates;
+    this.dts = other.dts;
     this.x = other.x;
     this.y = other.y;
     this.z = other.z;
@@ -354,6 +400,9 @@ class t8Sim extends theoryClass<theory> {
     this.dy = other.dy;
     this.dz = other.dz;
     this.msTimer = other.msTimer;
+    //this.isMX = other.isMX;
+    this.milestoneVariant = other.milestoneVariant;
+    this.ssPoint = other.ssPoint;
   }
   copy() {
     let copySim = new t8Sim(this.getDataForCopy());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2023" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
- Updated typescript target to be `es2023` instead of `es2022`.
- T8
  - Redid ranges for existing strategies
  - Added T8SingleMS strategies (only T8NoC3dSingleMS)
  - Implemented Coast strategies for all strategies that would utilize it
  - Redid the milestone priority route for most strategies
  - Cleaned up the Buy Conditions for variables
  - updated `t8Sim.copyFrom` with missing variables.
 - RZ
   - Replaced `swap:x.xxeX` with `x.xxeX` for RZBH strategies.